### PR TITLE
#get_width should return a positive number.

### DIFF
--- a/lib/progressbar.rb
+++ b/lib/progressbar.rb
@@ -128,7 +128,7 @@ class ProgressBar
       data = [0, 0, 0, 0].pack("SSSS")
       if @out.ioctl(tiocgwinsz, data) >= 0 then
         rows, cols, xpixels, ypixels = data.unpack("SSSS")
-        if cols >= 0 then cols else default_width end
+        if cols > 0 then cols else default_width end
       else
         default_width
       end


### PR DESCRIPTION
Ensuring #get_width returns a positive number. Terminals without termcap (such as emacs in shell-mode) return a TIOCGWINSZ of 0, which blows up in #clear where we use (get_width - 1).

Invoking common sense for a moment, if my terminal really is
zero-width, it doesn't matter what we print to screen. So let's be
generous and assume it's a dumb terminal, and return the default
width.
