### PR TITLE
Tag gems with the build date (rather than a date 2 years ago)

### DIFF
--- a/ruby-progressbar.gemspec
+++ b/ruby-progressbar.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.version = "0.0.10"
 
   s.author = "Satoru Takabayashi"
-  s.date = "2009-02-16"
+  s.date = Date.today.to_s
   s.description = "Ruby/ProgressBar is a text progress bar library for Ruby."
   s.email = "satoru@namazu.org"
   s.files = %w[GPL_LICENSE RUBY_LICENSE README.md lib/progressbar.rb test.rb]


### PR DESCRIPTION
When you build a gem, the gemspec is evaluated and re-serialized. All
dynamic values become static, once again. (for evidence of this, compare
ruby-progressbar.gemspec with the installed gemspec in your rubygems
folder.  Also, if you untar a gem with xzf, and examine metadata.gz,
you'll see the gemspec is actually stored in serialized YAML format, and
then converted back into a ruby format).

Therefore, this is a safe way to automatically store the current date in
a gem when you invoke gem build.  Currently, it's stuck and a Feb 2009
date, as evidence by the rubyforge page:

http://rubygems.org/gems/ruby-progressbar/stats
