### PR TITLE
Allows to change the title of the progress bar at runtime.

### DIFF
--- a/lib/progressbar.rb
+++ b/lib/progressbar.rb
@@ -29,7 +29,7 @@ class ProgressBar
     clear
     show
   end
-  attr_reader   :title
+  attr_accessor   :title
   attr_reader   :current
   attr_reader   :total
   attr_accessor :start_time
@@ -208,7 +208,8 @@ class ProgressBar
     show
   end
 
-  def inc (step = 1)
+  def inc (step = 1, new_title = nil)
+    @title = new_title.to_s if new_title
     @current += step
     @current = @total if @current > @total
     show_if_needed


### PR DESCRIPTION
Greetings guys,

I hope your day is going well. I am using the progress bar in rake tasks, and like displaying the id of the currently processed element as part of the progress bar. This allows me to restart the job where it left off in case of exceptions or errors. It's a pretty simple change that adds an optional parameter to "inc", so it shouldn't break any existing code. Please consider pulling this in, so that I can get rid of my fork, and keep using your fork. Thanks  :)

Examples:
progress_bar = ProgressBar.new '', 100

10.times do |i|
  progress_bar.inc 1, "processing step #{i}"
end
