### PR TITLE
use TermInfo to get screen width.

### DIFF
--- a/lib/progressbar.rb
+++ b/lib/progressbar.rb
@@ -8,6 +8,10 @@
 # You can redistribute it and/or modify it under the terms
 # of Ruby's license.
 #
+begin
+  require 'terminfo'
+rescue LoadError => ignore
+end
 
 class ProgressBar
   VERSION = "0.0.10"
@@ -122,7 +126,7 @@ class ProgressBar
 
   def get_width
     # FIXME: I don't know how portable it is.
-    default_width = 80
+    default_width = defined?(TermInfo) ? TermInfo.screen_width : 80
     begin
       tiocgwinsz = 0x5413
       data = [0, 0, 0, 0].pack("SSSS")


### PR DESCRIPTION
Hi. This patch let ProgressBar use TermInfo library to get current screen size.

TermInfo library is here.
- https://github.com/akr/ruby-terminfo
- http://rubygems.org/gems/ruby-terminfo

This would be platform independent and I run on iTerm 2 / Mac OS X 10.6.
To work without this library, I didnt add gem dependency.

thanks.
