### PR TITLE
Compatibility with non-tty devices

### DIFF
--- a/test.rb
+++ b/test.rb
@@ -138,6 +138,20 @@ class ProgressBarTest < Test::Unit::TestCase
     }
     pbar.halt
   end
+
+  class StubbedTtyProgressBar < ProgressBar
+    def tty?; false; end
+  end
+
+  def test_non_tty
+    total = 1024 * 1024
+    pbar = StubbedTtyProgressBar.new("non-tty compatible", total)
+    0.step(total, 2**14) {|x|
+      pbar.set(x)
+      sleep(SleepUnit)
+    }
+    pbar.finish
+  end
 end
 
 class ReversedProgressBarTest < ProgressBarTest


### PR DESCRIPTION
We have several scripts we use during application development that monitor long running processes with ruby-progressbar. We also have these scripts running in automated environments (such as CI), and the output in these situations is very noisy. We could alter the scripts, but I think it would be nicer if this library could gracefully handle these situations.

This patch adds a baseline behavior in non-tty environments so that things like log files aren't filled with every frame of the progress bar animation.
