### PR TITLE
offer a simple way to customize the #title_width

### DIFF
--- a/lib/progressbar.rb
+++ b/lib/progressbar.rb
@@ -23,8 +23,6 @@ class ProgressBar
     @finished_p = false
     @start_time = time_now
     @previous_time = @start_time
-    @title_width = 14
-    @format = "%-#{@title_width}s %3d%% %s %s"
     @format_arguments = [:title, :percentage, :bar, :stat]
     clear
     show
@@ -34,6 +32,15 @@ class ProgressBar
   attr_reader   :total
   attr_accessor :start_time
   attr_writer   :bar_mark
+  attr_writer   :title_width
+
+  def title_width
+    @title_width ||= 14
+  end
+
+  def format
+    @format || "%-#{title_width}s %3d%% %s %s"
+  end
 
   private
   def fmt_bar
@@ -59,7 +66,7 @@ class ProgressBar
   end
 
   def fmt_title
-    @title[0,(@title_width - 1)] + ":"
+    @title[0,(title_width - 1)] + ":"
   end
 
   def bar_width
@@ -151,7 +158,7 @@ class ProgressBar
       method = sprintf("fmt_%s", method)
       send(method)
     }
-    line = sprintf(@format, *arguments)
+    line = sprintf(format, *arguments)
 
     width = get_width
     if line.length == width - 1

--- a/test.rb
+++ b/test.rb
@@ -111,6 +111,21 @@ class ProgressBarTest < Test::Unit::TestCase
     pbar.finish
   end
 
+  def test_custom_bar
+    custom_bar_class = Class.new(ProgressBar) do
+      def title_width
+        20
+      end
+    end
+    pbar = custom_bar_class.new('test(custom)', 100)
+    total = 100
+    total.times {
+      sleep(SleepUnit)
+      pbar.inc
+    }
+    pbar.finish
+  end
+
   def test_timecop
     offset = 3905
     total = 10000


### PR DESCRIPTION
this patch allows to customize the #title_width of the progress-bar. either with an attribute accessor or with a subclass:

``` ruby
class MyProgressBar < ProgressBar
  def title_width
    22
  end
end
```

``` ruby
pbar = ProgressBar.new
pbar.title_width = 8
```
