### PR TITLE
Fix string slice bug in Ruby 1.8.7

### DIFF
--- a/lib/progress_bar/format/base.rb
+++ b/lib/progress_bar/format/base.rb
@@ -20,7 +20,7 @@ class ProgressBar
         molecules        = []
 
         format_string.scan(/%[a-zA-Z]/) do |match|
-          molecules << Molecule.new(match[1])
+          molecules << Molecule.new(match[1,1])
         end
 
         molecules


### PR DESCRIPTION
The current code crashes under Ruby 1.8.7 because the String class implements a single-digit slice differently (returning an integer instead of a one-character string).
