### PR TITLE
Fix ZeroDivisionError when total is zero

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-progressbar (1.0.0)
+    ruby-progressbar (1.0.1)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/progress_bar/components/progressable.rb
+++ b/lib/progress_bar/components/progressable.rb
@@ -59,6 +59,7 @@ class ProgressBar
       end
 
       def percentage_completed
+        return DEFAULT_TOTAL if total === 0
         # progress / total * 100
         #
         # Doing this way so we can avoid converting each

--- a/spec/progress_bar/components/progressable_spec.rb
+++ b/spec/progress_bar/components/progressable_spec.rb
@@ -27,4 +27,11 @@ describe ProgressBar::Components::Progressable do
       ProgressableClass.new.smoothing.should eql 0.1
     end
   end
+
+  describe '#percentage_completed' do
+    it 'returns the default total if total is zero' do
+      subject.total = 0
+      subject.percentage_completed.should eql 100
+    end
+  end
 end


### PR DESCRIPTION
When calculating the `percentage_completed`, if the local `total` is zero, a `ZeroDivisionError` is raised.

This checks for a 0 `total` and returns `DEFAULT_TOTAL` instead.

I ran into this via Fuubar and RSpec. Running a spec file that had no examples (so 0 of 0 completed), the `ZeroDivisionError` was raised.
