### PR TITLE
Fix overriding the progress bar length with an environment variable.

### DIFF
--- a/lib/progress_bar/length_calculator.rb
+++ b/lib/progress_bar/length_calculator.rb
@@ -2,6 +2,7 @@ class ProgressBar
   module LengthCalculator
     def initialize(options)
       @length_override = ENV['RUBY_PROGRESS_BAR_LENGTH'] || options[:length]
+      @length_override = @length_override.to_i if @length_override
 
       super()
     end

--- a/spec/progress_bar/base_spec.rb
+++ b/spec/progress_bar/base_spec.rb
@@ -41,6 +41,17 @@ describe ProgressBar::Base do
       end
     end
 
+    context 'and the RUBY_PROGRESS_BAR_LENGTH environment variable exists' do
+      before { ENV['RUBY_PROGRESS_BAR_LENGTH'] = '44' ; @progressbar = ProgressBar::Base.new }
+      after { ENV['RUBY_PROGRESS_BAR_LENGTH'] = nil }
+
+      describe '#length' do
+        it 'returns the length of the environment variable as an integer' do
+          @progressbar.send(:length).should == 44
+        end
+      end
+    end
+
     context 'and options are passed' do
       before { @progressbar = ProgressBar::Base.new(:title => 'We All Float', :total => 12, :output => STDOUT, :progress_mark => 'x', :length => 88, :starting_at => 5) }
 


### PR DESCRIPTION
Environment variables are always strings, even when set in Ruby. The progress bar does not convert the string to an integer, but needs a numeric to base its calculations on.
