### PR TITLE
allows to inclue ANSI SGR codes into molecules

### DIFF
--- a/lib/ruby-progressbar/format/base.rb
+++ b/lib/ruby-progressbar/format/base.rb
@@ -19,8 +19,9 @@ class ProgressBar
         placeholder_length  = remaining_molecules * 2
 
         processed_string.gsub! '%%', '%'
-
-        leftover_bar_length = environment.send(:length) - processed_string.length + placeholder_length
+        # lenght calculated without eventual ANSI SGR codes
+        processed_string_length = processed_string.gsub(/\e\[[\d;]+m/, '').length
+        leftover_bar_length = environment.send(:length) - processed_string_length + placeholder_length
         leftover_bar_length = leftover_bar_length < 0 ? 0 : leftover_bar_length
 
         bar_molecules.each do |molecule|


### PR DESCRIPTION
Simple patch that removes eventual ANSI SGR codes from the calculation of the length, so allowing to pass colors and styles into progress bars molecules.
