### PR TITLE
Prevent exception for long file names

### DIFF
--- a/lib/ruby-progressbar/formatter.rb
+++ b/lib/ruby-progressbar/formatter.rb
@@ -73,6 +73,7 @@ class ProgressBar
     end
 
     def complete_bar(length)
+      length = 0 if length < 0
       @bar.length = length
       @bar.to_s
     end


### PR DESCRIPTION
File names over 80 chars on a 80 column terminal blow up.
