### PR TITLE
Add option to set the :remainder_mark.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The following are the list of options you can use:
 * `:total` - _(Defaults to `100`)_ The total number of the items that can be completed.
 * `:starting_at` - _(Defaults to `0`)_ The number of items that should be considered completed when the bar first starts.  This is also the default number that the bar will be set to if `#reset` is called.
 * `:progress_mark` - _(Defaults to `=`)_ The mark which indicates the amount of progress that has been made.
+* `:remainder_mark` - _(Defaults to ` `)_ The mark which indicates the remaining amount of progress to be made.
 * `:format` - _(Defaults to `%t: |%B|`)_ The format string which determines how the bar is displayed.  See [**Formatting**](#formatting) below.
 * `:length` - _(Defaults to full width if possible, otherwise `80`)_ The preferred width of the entire progress bar including any format options.
 * `:output` - _(Defaults to `STDOUT`)_ All output will be sent to this object.  Can be any object which responds to `.print`.
@@ -267,6 +268,7 @@ _Note: If the terminal width is less than 20 characters or ruby-progressbar is b
 The following items can be set at any time.  Changes cause an immediate bar refresh so no other action is needed:
 
 * `#progress_mark=`: Sets the string used to represent progress along the bar.
+* `#remainder_mark=`: Sets the string used to represent the empty part of the bar.
 * `#title=`: Sets the string used to represent the items the bar is tracking (or I guess whatever else you want it to be).
 * `#format(format_string)`: If you need to adjust the format that the bar uses when rendering itself, just pass in a string in the same format as describe [above](#formatting).
 

--- a/lib/ruby-progressbar/base.rb
+++ b/lib/ruby-progressbar/base.rb
@@ -92,6 +92,10 @@ class ProgressBar
       with_update { @bar.progress_mark = mark }
     end
 
+    def remainder_mark=(mark)
+      with_update { @bar.remainder_mark = mark }
+    end
+
     def title=(title)
       with_update { super }
     end

--- a/lib/ruby-progressbar/components/bar.rb
+++ b/lib/ruby-progressbar/components/bar.rb
@@ -4,9 +4,11 @@ class ProgressBar
       include Progressable
 
       DEFAULT_PROGRESS_MARK                    = '='
+      DEFAULT_REMAINDER_MARK                   = ' '
       DEFAULT_UNKNOWN_PROGRESS_ANIMATION_STEPS = ['=---', '-=--', '--=-', '---=']
 
       attr_accessor :progress_mark
+      attr_accessor :remainder_mark
       attr_accessor :length
       attr_accessor :unknown_progress_animation_steps
 
@@ -15,6 +17,7 @@ class ProgressBar
 
         self.unknown_progress_animation_steps = options[:unknown_progress_animation_steps] || DEFAULT_UNKNOWN_PROGRESS_ANIMATION_STEPS
         self.progress_mark                    = options[:progress_mark]                    || DEFAULT_PROGRESS_MARK
+        self.remainder_mark                   = options[:remainder_mark]                   || DEFAULT_REMAINDER_MARK
       end
 
       def to_s(options = {:format => :standard})
@@ -44,7 +47,7 @@ class ProgressBar
 
           unknown_incomplete_string[0, incomplete_length]
         else
-          ' ' * incomplete_length
+          remainder_mark * incomplete_length
         end
       end
 

--- a/spec/lib/ruby-progressbar/base_spec.rb
+++ b/spec/lib/ruby-progressbar/base_spec.rb
@@ -269,6 +269,15 @@ describe ProgressBar::Base do
         end
       end
 
+      describe '#remainder_mark=' do
+        it 'changes the mark used to represent the remaining part of the bar and updates the output' do
+          @progressbar.remainder_mark = 'x'
+
+          @output.rewind
+          @output.read.should match /\rProgress: \|======#{'x' * 62}\|\r\z/
+        end
+      end
+
       describe '#title=' do
         it 'changes the title used to represent the items being progressed and updates the output' do
           @progressbar.title = 'Items'

--- a/spec/lib/ruby-progressbar/components/bar_spec.rb
+++ b/spec/lib/ruby-progressbar/components/bar_spec.rb
@@ -17,6 +17,12 @@ describe ProgressBar::Components::Bar do
         end
       end
 
+      describe '#remainder_mark' do
+        it 'returns the default remainder mark' do
+          @progressbar.remainder_mark.should eql ProgressBar::Components::Bar::DEFAULT_REMAINDER_MARK
+        end
+      end
+
       context 'and the bar has not been started' do
         describe '#progress' do
           it 'returns the default beginning position' do
@@ -47,7 +53,7 @@ describe ProgressBar::Components::Bar do
     end
 
     context 'and options are passed' do
-      before { @progressbar = ProgressBar::Components::Bar.new(:total => 12, :progress_mark => 'x') }
+      before { @progressbar = ProgressBar::Components::Bar.new(:total => 12, :progress_mark => 'x', :remainder_mark => '.') }
 
       describe '#total' do
         it 'returns the overridden total' do
@@ -58,6 +64,12 @@ describe ProgressBar::Components::Bar do
       describe '#progress_mark' do
         it 'returns the overridden mark' do
           @progressbar.progress_mark.should eql 'x'
+        end
+      end
+
+      describe '#remainder_mark' do
+        it 'returns the overridden mark' do
+          @progressbar.remainder_mark.should eql '.'
         end
       end
     end


### PR DESCRIPTION
Added an option to set the :remainder_mark (along the lines of :progress_mark) that allows the user to set the character used to represent the remaining progress to be made along the bar. Some pretty cool effects can be achieved by using Unicode characters for the two marks, e.g. a small dot for the remainder and a big block for the progress mark.
