### PR TITLE
Estimate

### DIFF
--- a/lib/ruby-progressbar/components/estimated_timer.rb
+++ b/lib/ruby-progressbar/components/estimated_timer.rb
@@ -43,12 +43,8 @@ class ProgressBar
         end
       end
 
-      def average_seconds_per_each
-        elapsed_whole_seconds.to_f / self.running_average
-      end
-
       def estimated_seconds_remaining
-        ((average_seconds_per_each * self.total) - elapsed_whole_seconds.to_f).floor
+        (elapsed_seconds * (self.total / self.running_average  - 1)).round
       end
 
       def out_of_bounds_time

--- a/spec/lib/ruby-progressbar/base_spec.rb
+++ b/spec/lib/ruby-progressbar/base_spec.rb
@@ -654,7 +654,7 @@ describe ProgressBar::Base do
         end
 
         it 'displays the estimated time remaining when using the "%e" flag' do
-          progressbar.to_s('%e').should match /^ ETA: 01:02:02\z/
+          progressbar.to_s('%e').should match /^ ETA: 01:02:03\z/
         end
       end
 

--- a/spec/lib/ruby-progressbar/components/estimated_timer_spec.rb
+++ b/spec/lib/ruby-progressbar/components/estimated_timer_spec.rb
@@ -155,9 +155,37 @@ describe ProgressBar::Components::EstimatedTimer do
           end
 
           it 'displays the correct time remaining' do
-            @estimated_time.to_s.should eql ' ETA: 105:33:19'
+            @estimated_time.to_s.should eql ' ETA: 105:33:20'
           end
         end
+      end
+    end
+
+    it 'displays a good estimate for regular increments' do
+      begin
+        Timecop.freeze(t = Time.now)
+        n = 10
+        estimated_time = ProgressBar::Components::EstimatedTimer.new(:total => n)
+        estimated_time.start
+        results = (1..n).map do |i|
+          Timecop.freeze(t + 0.5 * i)
+          estimated_time.increment
+          estimated_time.to_s
+        end
+        results.should == [
+          ' ETA: 00:00:05',
+          ' ETA: 00:00:04',
+          ' ETA: 00:00:04',
+          ' ETA: 00:00:03',
+          ' ETA: 00:00:03',
+          ' ETA: 00:00:02',
+          ' ETA: 00:00:02',
+          ' ETA: 00:00:01',
+          ' ETA: 00:00:01',
+          ' ETA: 00:00:00',
+        ]
+      ensure
+        Timecop.return
       end
     end
   end


### PR DESCRIPTION
I noticed while writing [with_progress](http://github.com/marcandre/with_progress) (which you might want to consider including in this gem?) that the time estimations were off.
The progress estimation is good, it's only the remaining time calculation that is incorrect. This PR fixes it.

The spec mimics a loop with iterations taking exactly 0.5 seconds.
The improvement should be quite obvious, as without the fix, the test fails with:

```
  expected: [" ETA: 00:00:05", " ETA: 00:00:04", " ETA: 00:00:04", " ETA: 00:00:03", " ETA: 00:00:03", " ETA: 00:00:02", " ETA: 00:00:02", " ETA: 00:00:01", " ETA: 00:00:01", " ETA: 00:00:00"]
       got: [" ETA: 00:00:00", " ETA: 00:00:04", " ETA: 00:00:02", " ETA: 00:00:03", " ETA: 00:00:02", " ETA: 00:00:02", " ETA: 00:00:01", " ETA: 00:00:01", " ETA: 00:00:00", " ETA: 00:00:00"] (using ==)
```

Thanks for `ruby-progressbar`
