### PR TITLE
Ensure output_string is not nil, which may happen for non-TTY output.

### DIFF
--- a/lib/ruby-progressbar/base.rb
+++ b/lib/ruby-progressbar/base.rb
@@ -196,8 +196,10 @@ class ProgressBar
 
         self.last_update_length = formatted_string.length
 
-        output.print output_string + eol
-        output.flush
+        if output_string
+          output.print output_string + eol
+          output.flush
+        end
       end
     end
 


### PR DESCRIPTION
String[start,length] may return nil if the initial index falls outside the strength or the length is negative. Therefore the output_string may be nil for non-TTY cases, where for example stop() is called for unknown length files in middle of transaction, etc.
