### PR TITLE
Remove warnings from `lib` code

### DIFF
--- a/lib/ruby-progressbar.rb
+++ b/lib/ruby-progressbar.rb
@@ -7,6 +7,6 @@ require 'ruby-progressbar/base'
 
 class ProgressBar
   def self.create(*args)
-    ProgressBar::Base.new *args
+    ProgressBar::Base.new(*args)
   end
 end

--- a/lib/ruby-progressbar/base.rb
+++ b/lib/ruby-progressbar/base.rb
@@ -6,7 +6,7 @@ class ProgressBar
     DEFAULT_OUTPUT_STREAM = $stdout
 
     def initialize(options = {})
-      self.output       = options[:output] || DEFAULT_OUTPUT_STREAM
+      @output           = options[:output] || DEFAULT_OUTPUT_STREAM
       autostart         = options.fetch(:autostart, true)
 
       super(options)
@@ -112,7 +112,7 @@ class ProgressBar
     # Output
     #
     def clear
-      self.last_update_length = 0
+      @last_update_length = 0
 
       if output.tty?
         output.print clear_string
@@ -143,10 +143,9 @@ class ProgressBar
       "#<ProgressBar:#{progress}/#{total || 'unknown'}>"
     end
 
-  private
-    attr_accessor   :output,
-                    :last_update_length
+    attr_reader :output
 
+  private
     def clear_string
       "#{" " * length}"
     end
@@ -196,7 +195,7 @@ class ProgressBar
           output_string    = formatted_string[last_update_length..-1]
         end
 
-        self.last_update_length = formatted_string.length
+        @last_update_length = formatted_string.length
 
         output.print output_string + eol
         output.flush

--- a/lib/ruby-progressbar/components/estimated_timer.rb
+++ b/lib/ruby-progressbar/components/estimated_timer.rb
@@ -66,7 +66,7 @@ class ProgressBar
       end
 
       class As
-        private *instance_methods.select { |m| m !~ /(^__|^\W|^binding$)/ }
+        private(*instance_methods.select { |m| m !~ /(^__|^\W|^binding$)/ })
 
         def initialize(subject, ancestor)
           @subject = subject

--- a/lib/ruby-progressbar/components/rate.rb
+++ b/lib/ruby-progressbar/components/rate.rb
@@ -49,7 +49,7 @@ class ProgressBar
       end
 
       class As
-        private *instance_methods.select { |m| m !~ /(^__|^\W|^binding$)/ }
+        private(*instance_methods.select { |m| m !~ /(^__|^\W|^binding$)/ })
 
         def initialize(subject, ancestor)
           @subject = subject

--- a/lib/ruby-progressbar/components/timer.rb
+++ b/lib/ruby-progressbar/components/timer.rb
@@ -25,10 +25,12 @@ class ProgressBar
       end
 
       def started?
+        @started_at ||= nil
         !!@started_at
       end
 
       def stopped?
+        @stopped_at ||= nil
         !!@stopped_at
       end
 

--- a/lib/ruby-progressbar/formatter.rb
+++ b/lib/ruby-progressbar/formatter.rb
@@ -30,6 +30,7 @@ class ProgressBar
 
   private
     def format_string=(format_string)
+      @format_string ||= nil
       if @format_string != format_string
         @format_string = format_string
         @format        = ProgressBar::Format::Base.new(format_string)

--- a/lib/ruby-progressbar/length_calculator.rb
+++ b/lib/ruby-progressbar/length_calculator.rb
@@ -4,6 +4,7 @@ class ProgressBar
       @length_override = ENV['RUBY_PROGRESS_BAR_LENGTH'] || options[:length]
       @length_override = @length_override.to_i if @length_override
 
+      @current_length = nil
       super()
     end
 
@@ -39,7 +40,7 @@ class ProgressBar
       require 'io/console'
 
       def dynamic_width
-        rows, columns = IO.console.winsize
+        _rows, columns = IO.console.winsize
         columns
       end
     rescue LoadError


### PR DESCRIPTION
Right now, anyone who uses the [Fuubar] Rspec formatter gets a list of warnings coming from ruby-progressbar. They look like this:

```
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar.rb:10: warning: `*' interpreted as argument prefix
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/length_calculator.rb:42: warning: assigned but unused variable - rows
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/components/estimated_timer.rb:69: warning: `*' interpreted as argument prefix
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/components/rate.rb:52: warning: `*' interpreted as argument prefix
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/base.rb:147: warning: private attribute?
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/base.rb:147: warning: private attribute?
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/base.rb:154: warning: method redefined; discarding old last_update_length
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/formatter.rb:33: warning: instance variable @format_string not initialized
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/components/timer.rb:32: warning: instance variable @stopped_at not initialized
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/components/timer.rb:32: warning: instance variable @stopped_at not initialized
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/formatter.rb:33: warning: instance variable @format_string not initialized
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/components/timer.rb:32: warning: instance variable @stopped_at not initialized
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/components/timer.rb:32: warning: instance variable @stopped_at not initialized
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/length_calculator.rb:12: warning: instance variable @current_length not initialized
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/components/timer.rb:32: warning: instance variable @stopped_at not initialized
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/components/timer.rb:28: warning: instance variable @started_at not initialized
/Users/grayson/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/ruby-progressbar-1.6.0/lib/ruby-progressbar/components/timer.rb:32: warning: instance variable @stopped_at not initialized
```

This pull request fixes those warnings. You might want a minor version bump with it.

Thanks for all your hard work with this library! It's a pleasure to use. (=
