### PR TITLE
Display warnings when testing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     timecop (0.6.1)
+    warning_filter (0.0.2)
 
 PLATFORMS
   ruby
@@ -52,3 +53,4 @@ DEPENDENCIES
   ruby-prof (~> 0.13.0)
   ruby-progressbar!
   timecop (~> 0.6.0)
+  warning_filter (~> 0.0.2)

--- a/ruby-progressbar.gemspec
+++ b/ruby-progressbar.gemspec
@@ -32,6 +32,7 @@ THEDOCTOR
   s.add_development_dependency('rspec',                     '~> 3.0.0beta')
   s.add_development_dependency('rspectacular',              '~> 0.21.6')
   s.add_development_dependency('fuubar',                    '~> 2.0beta')
+  s.add_development_dependency('warning_filter',            '~> 0.0.2')
   s.add_development_dependency('timecop',                   '~> 0.6.0')
   s.add_development_dependency('codeclimate-test-reporter', '~> 0.3.0')
 end

--- a/spec/lib/ruby-progressbar/base_spec.rb
+++ b/spec/lib/ruby-progressbar/base_spec.rb
@@ -1,4 +1,4 @@
-require 'rspectacular'
+require 'spec_helper'
 require 'support/time'
 require 'stringio'
 

--- a/spec/lib/ruby-progressbar/components/bar_spec.rb
+++ b/spec/lib/ruby-progressbar/components/bar_spec.rb
@@ -1,4 +1,4 @@
-require 'rspectacular'
+require 'spec_helper'
 
 describe ProgressBar::Components::Bar do
   context 'when a new bar is created' do

--- a/spec/lib/ruby-progressbar/components/elapsed_timer_spec.rb
+++ b/spec/lib/ruby-progressbar/components/elapsed_timer_spec.rb
@@ -1,4 +1,4 @@
-require 'rspectacular'
+require 'spec_helper'
 
 describe ProgressBar::Components::ElapsedTimer do
   before { @timer = ProgressBar::Components::ElapsedTimer.new }

--- a/spec/lib/ruby-progressbar/components/estimated_timer_spec.rb
+++ b/spec/lib/ruby-progressbar/components/estimated_timer_spec.rb
@@ -1,4 +1,4 @@
-require 'rspectacular'
+require 'spec_helper'
 require 'support/time'
 
 describe ProgressBar::Components::EstimatedTimer do

--- a/spec/lib/ruby-progressbar/components/progressable_spec.rb
+++ b/spec/lib/ruby-progressbar/components/progressable_spec.rb
@@ -1,4 +1,4 @@
-require 'rspectacular'
+require 'spec_helper'
 
 class ProgressableClass
   include ProgressBar::Components::Progressable

--- a/spec/lib/ruby-progressbar/components/throttle_spec.rb
+++ b/spec/lib/ruby-progressbar/components/throttle_spec.rb
@@ -1,4 +1,4 @@
-require 'rspectacular'
+require 'spec_helper'
 
 describe ProgressBar::Components::Throttle do
   context 'given a numeric period' do

--- a/spec/lib/ruby-progressbar/running_average_calculator_spec.rb
+++ b/spec/lib/ruby-progressbar/running_average_calculator_spec.rb
@@ -1,4 +1,4 @@
-require 'rspectacular'
+require 'spec_helper'
 
 describe ProgressBar::RunningAverageCalculator do
   describe '.calculate' do

--- a/spec/lib/ruby-progressbar/time_spec.rb
+++ b/spec/lib/ruby-progressbar/time_spec.rb
@@ -1,4 +1,4 @@
-require 'rspectacular'
+require 'spec_helper'
 
 class TimeMockedWithTimecop
   def self.now; end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+require "rspectacular"
+require "warning_filter"
+
+RSpec.configure do |config|
+  config.warnings = true
+end


### PR DESCRIPTION
Hey again – Warnings have been a popular topic here (see #81, #87 and #88).

If you like, this pull request is the testing setup I used to track down the warnings in the code, without seeing warnings from other gems. It should help keep ruby-progressbar warning free in the future.

Cheers!
