### PR TITLE
Bugfix: ETA works again, when initializeing with a non zero starting_at.

### DIFF
--- a/lib/ruby-progressbar/progress.rb
+++ b/lib/ruby-progressbar/progress.rb
@@ -89,7 +89,7 @@ class   Progress
   end
 
   def none?
-    progress.zero?
+    running_average.zero? || progress.zero?
   end
 
   def unknown?

--- a/spec/ruby-progressbar/base_spec.rb
+++ b/spec/ruby-progressbar/base_spec.rb
@@ -866,6 +866,13 @@ describe ProgressBar::Base do
           progressbar = ProgressBar::Base.new
           expect(progressbar.to_s('%e')).to match(/^ ETA: \?\?:\?\?:\?\?\z/)
         end
+
+        context 'when started_at is set to a value greater than 0' do
+          it 'displays unknown time until finished when passed the "%e" flag' do
+            progressbar = ProgressBar::Base.new(:starting_at =>  1)
+            expect(progressbar.to_s('%e')).to match(/^ ETA: \?\?:\?\?:\?\?\z/)
+          end
+        end
       end
 
       context 'when called after #start' do


### PR DESCRIPTION
Otherwise a "FloatDomainError Infinity" error was raised:

``` ruby
> ProgressBar.create({starting_at: 0, format: '%e'})
=> #<ProgressBar:0/100>
> ProgressBar.create({starting_at: 1, format: '%e'})
FloatDomainError: Infinity
from [...]ruby/gems/2.1.0/gems/ruby-progressbar-1.7.0/lib/ruby-progressbar/components/time.rb:90:in `round`
```

This PR fixes the issue. Seems to be broken since ed6317453782e510c4d0644e20cc76b10c572e0d .
