### PR TITLE
Prevent `method redefined` warnings being generated by replacing uses of `attr_accessor`

### DIFF
--- a/lib/ruby-progressbar/calculators/length.rb
+++ b/lib/ruby-progressbar/calculators/length.rb
@@ -1,8 +1,8 @@
 class   ProgressBar
 module  Calculators
 class   Length
-  attr_accessor :length_override,
-                :current_length
+  attr_reader   :length_override
+  attr_accessor :current_length
 
   def initialize(options)
     self.length_override = options[:length]

--- a/lib/ruby-progressbar/components/time.rb
+++ b/lib/ruby-progressbar/components/time.rb
@@ -47,8 +47,8 @@ class   Time
     estimated_with_elapsed_fallback
   end
 
-  attr_accessor :out_of_bounds_time_format,
-                :timer,
+  attr_reader   :out_of_bounds_time_format
+  attr_accessor :timer,
                 :progress
 
   def out_of_bounds_time_format=(format)

--- a/lib/ruby-progressbar/outputs/non_tty.rb
+++ b/lib/ruby-progressbar/outputs/non_tty.rb
@@ -41,7 +41,7 @@ class   NonTty < Output
 
   protected
 
-  attr_accessor :last_update_length
+  attr_writer :last_update_length
 end
 end
 end

--- a/lib/ruby-progressbar/progress.rb
+++ b/lib/ruby-progressbar/progress.rb
@@ -6,9 +6,10 @@ class   Progress
   DEFAULT_BEGINNING_POSITION = 0
   DEFAULT_SMOOTHING          = 0.1
 
-  attr_accessor             :total,
-                            :progress,
-                            :starting_position,
+  attr_reader               :total,
+                            :progress
+
+  attr_accessor             :starting_position,
                             :running_average,
                             :smoothing
 


### PR DESCRIPTION
 Replace uses of `attr_accessor` with:
* `attr_reader`  where a setter function is already defined,
* `attr_writer` where a getter function is already defined

Fixes #81

Thanks for your work on this awesome gem :)
