### PR TITLE
Improve format for unknown total (%C option)

### DIFF
--- a/lib/ruby-progressbar/format/molecule.rb
+++ b/lib/ruby-progressbar/format/molecule.rb
@@ -5,7 +5,7 @@ class   Molecule
     :t => [:title_comp,   :title],
     :T => [:title_comp,   :title],
     :c => [:progressable, :progress],
-    :C => [:progressable, :total],
+    :C => [:progressable, :formatted_total],
     :p => [:percentage,   :percentage],
     :P => [:percentage,   :percentage_with_precision],
     :j => [:percentage,   :justified_percentage],

--- a/lib/ruby-progressbar/progress.rb
+++ b/lib/ruby-progressbar/progress.rb
@@ -67,6 +67,10 @@ class   Progress
                                                                  smoothing)
   end
 
+  def formatted_total
+    total || '??'
+  end
+
   def total=(new_total)
     fail ProgressBar::InvalidProgressError,
          "You can't set the item's total value to less than the current progress." \

--- a/spec/ruby-progressbar/base_spec.rb
+++ b/spec/ruby-progressbar/base_spec.rb
@@ -800,6 +800,12 @@ RSpec.describe ProgressBar::Base do
         expect(progressbar.to_s('%C')).to match(/^100\z/)
       end
 
+      it 'displays ?? when the total is unknown and when passed the "%C" format flag' do
+        progressbar = ProgressBar::Base.new(:total => nil)
+
+        expect(progressbar.to_s('%C')).to match(/^\?\?\z/)
+      end
+
       it 'displays the percentage complete when passed the "%p" format flag' do
         progressbar = ProgressBar::Base.new(:starting_at => 33, :total => 200)
 


### PR DESCRIPTION
In cases where the total number of items is unknown, display the %C (total) option as '??', rather than blank as is current behavior.
