### PR TITLE
Update warning_filter to fix `require_relative`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     ruby-prof (0.15.8)
     thor (0.19.1)
     timecop (0.6.1)
-    warning_filter (0.0.5)
+    warning_filter (0.0.6)
 
 PLATFORMS
   ruby

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'rspectacular'
-require 'warning_filter' if Kernel.respond_to?(:require_relative)
+require 'warning_filter'
 
 RSpec.configure do |config|
   config.warnings = true


### PR DESCRIPTION
`warning_filter` version 0.0.5 used `require_relative`,
which is not supported by Ruby 0.8.7.
To get around this, we were not including `warning_filter`
if the Ruby version didn't support `require_relative`.

`warning_filter` version 0.0.6 no longer uses `require_relative`,
and therefore can be used in any current Ruby version.
