### PR TITLE
Performance: don't shell out when it's avoidable.

### DIFF
--- a/lib/ruby-progressbar/calculators/length.rb
+++ b/lib/ruby-progressbar/calculators/length.rb
@@ -2,10 +2,12 @@ class   ProgressBar
 module  Calculators
 class   Length
   attr_reader   :length_override
-  attr_accessor :current_length
+  attr_accessor :current_length,
+                :output
 
   def initialize(options = {})
     self.length_override = options[:length]
+    self.output = options[:output]
     self.current_length  = nil
   end
 
@@ -51,7 +53,9 @@ class   Length
     require 'io/console'
 
     def dynamic_width
-      if IO.console
+      if output && output.tty?
+        dynamic_width_via_output
+      elsif IO.console
         dynamic_width_via_io_object
       else
         dynamic_width_via_system_calls
@@ -61,6 +65,11 @@ class   Length
     def dynamic_width
       dynamic_width_via_system_calls
     end
+  end
+
+  def dynamic_width_via_output
+    _rows, columns = output.winsize
+    columns
   end
 
   def dynamic_width_via_io_object

--- a/lib/ruby-progressbar/output.rb
+++ b/lib/ruby-progressbar/output.rb
@@ -7,7 +7,7 @@ class   Output
   def initialize(options = {})
     self.bar               = options[:bar]
     self.stream            = options[:output] || DEFAULT_OUTPUT_STREAM
-    self.length_calculator = Calculators::Length.new({ output: stream }.merge(options))
+    self.length_calculator = Calculators::Length.new({ :output => stream }.merge(options))
     self.throttle          = Throttle.new(options)
   end
 

--- a/lib/ruby-progressbar/output.rb
+++ b/lib/ruby-progressbar/output.rb
@@ -7,7 +7,7 @@ class   Output
   def initialize(options = {})
     self.bar               = options[:bar]
     self.stream            = options[:output] || DEFAULT_OUTPUT_STREAM
-    self.length_calculator = Calculators::Length.new(options)
+    self.length_calculator = Calculators::Length.new({ output: stream }.merge(options))
     self.throttle          = Throttle.new(options)
   end
 

--- a/spec/ruby-progressbar/calculators/length_spec.rb
+++ b/spec/ruby-progressbar/calculators/length_spec.rb
@@ -43,6 +43,41 @@ describe  Length do
     expect(length_calculator.length).to eql 99
   end
 
+  it 'if output is a tty, uses it to calculate length in unix environments' do
+    stream = instance_double('IO')
+    expect(stream).to receive(:tty?).and_return true
+    expect(stream).to receive(:winsize).and_return [123, 456]
+    expect(IO).not_to receive(:console)
+
+    length_calculator = Calculators::Length.new(output: stream)
+    allow(length_calculator).to receive(:unix?).and_return(true)
+    expect(length_calculator.length).to eql 456
+  end
+
+  it 'if output is null, falls back on IO.console to calculate length in unix environments' do
+    console = instance_double('IO')
+    expect(IO).to receive(:console).and_return(console).at_least(:once)
+    expect(console).to receive(:winsize).and_return [123, 456]
+
+    length_calculator = Calculators::Length.new
+    allow(length_calculator).to receive(:unix?).and_return(true)
+    expect(length_calculator.length).to eql 456
+  end
+
+  it 'if output is not a tty, falls back on IO.console to calculate length in unix environments' do
+    stream = instance_double('IO')
+    expect(stream).to receive(:tty?).and_return false
+    expect(stream).not_to receive(:winsize)
+
+    console = instance_double('IO')
+    expect(IO).to receive(:console).and_return(console).at_least(:once)
+    expect(console).to receive(:winsize).and_return [123, 456]
+
+    length_calculator = Calculators::Length.new(output: stream)
+    allow(length_calculator).to receive(:unix?).and_return(true)
+    expect(length_calculator.length).to eql 456
+  end
+
   it 'defaults to 80 if it is not a Unix environment' do
     length_calculator = Calculators::Length.new
 

--- a/spec/ruby-progressbar/calculators/length_spec.rb
+++ b/spec/ruby-progressbar/calculators/length_spec.rb
@@ -49,7 +49,7 @@ describe  Length do
     expect(stream).to receive(:winsize).and_return [123, 456]
     expect(IO).not_to receive(:console)
 
-    length_calculator = Calculators::Length.new(output: stream)
+    length_calculator = Calculators::Length.new(:output => stream)
     allow(length_calculator).to receive(:unix?).and_return(true)
     expect(length_calculator.length).to eql 456
   end
@@ -73,7 +73,7 @@ describe  Length do
     expect(IO).to receive(:console).and_return(console).at_least(:once)
     expect(console).to receive(:winsize).and_return [123, 456]
 
-    length_calculator = Calculators::Length.new(output: stream)
+    length_calculator = Calculators::Length.new(:output => stream)
     allow(length_calculator).to receive(:unix?).and_return(true)
     expect(length_calculator.length).to eql 456
   end

--- a/spec/ruby-progressbar/output_spec.rb
+++ b/spec/ruby-progressbar/output_spec.rb
@@ -39,12 +39,12 @@ describe Output do
   end
 
   it 'passes the output stream to the length calculator' do
-    expect(Calculators::Length).to receive(:new).with(output: output_io)
-    ProgressBar::Output.new(output: output_io)
+    expect(Calculators::Length).to receive(:new).with(:output => output_io)
+    ProgressBar::Output.new(:output => output_io)
   end
 
   it 'passes stdout to the length calculator if output is not specified' do
-    expect(Calculators::Length).to receive(:new).with(output: $stdout)
+    expect(Calculators::Length).to receive(:new).with(:output => $stdout)
     ProgressBar::Output.new
   end
 end

--- a/spec/ruby-progressbar/output_spec.rb
+++ b/spec/ruby-progressbar/output_spec.rb
@@ -37,5 +37,15 @@ describe Output do
     expect(output_io.read).to eql "Progress |         |\r" \
                                   "We All Float\n"
   end
+
+  it 'passes the output stream to the length calculator' do
+    expect(Calculators::Length).to receive(:new).with(output: output_io)
+    ProgressBar::Output.new(output: output_io)
+  end
+
+  it 'passes stdout to the length calculator if output is not specified' do
+    expect(Calculators::Length).to receive(:new).with(output: $stdout)
+    ProgressBar::Output.new
+  end
 end
 end


### PR DESCRIPTION
## Why This Change Is Necessary

<!--- Identify the High Level Type of Change -->
- [x] Bug Fix
- [ ] New Feature

When using ruby-progressbar with the Fuubar RSpec formatter in Zeus, the output is much, much slower than using any other RSpec formatters.

Using ruby-progressbar outside of Zeus does not add this overhead. Using Zeus with other formatters also does not add this overhead. I figured it must have something to do with the combination.

## How These Changes Address the Issue

When running in Zeus, `IO.console` was returning `nil` so ruby-progressbar was resorting to shelling out to `stty` and `tput` to get the console width.  Launching a process on every increment adds a lot of overhead time to the progress bar. (1/20 of a second on my Linux machine.)

In this fix, I pass the output stream to the length calculator. If the stream is a tty, I call its `winsize` method instead of launching processes. 

## Side Effects Caused By This Change

- [ ] This Causes a Breaking Change

No side-effects.

## Screenshots

Running 100 _empty specs_ in RSpec before this change:

![before](https://user-images.githubusercontent.com/16927/30502066-9fb779e2-9a19-11e7-8a7d-9ca384849f41.gif)

After this change:

![after](https://user-images.githubusercontent.com/16927/30502071-a3bbdd62-9a19-11e7-9a07-614bdc37c50c.gif)



## Checklist:
- [x] I have run `rubocop` against the codebase
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

NOTE: I ran `rubocop` but it fails on master _and_ on my branch:

```
$ rubocop
/Users/brian_morearty/airlab/repos/ruby-progressbar/.rubocop.yml: Style/ClosingParenthesisIndentation has the wrong namespace - should be Layout
...
```
