### PR TITLE
fix changelog uri in both gemspecs to point to master CHANGELOG.md

### DIFF
--- a/progressbar.gemspec
+++ b/progressbar.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata      = {
     'allowed_push_host' => 'https://rubygems.org',
     'bug_tracker_uri'   => 'https://github.com/jfelchner/ruby-progressbar/issues',
-    'changelog_uri'     => 'https://github.com/jfelchner/ruby-progressbar/CHANGELOG.md',
+    'changelog_uri'     => 'https://github.com/jfelchner/ruby-progressbar/blob/master/CHANGELOG.md',
     'documentation_uri' => "https://github.com/jfelchner/ruby-progressbar/tree/releases/v#{ProgressBar::VERSION}",
     'homepage_uri'      => 'https://github.com/jfelchner/ruby-progressbar',
     'source_code_uri'   => 'https://github.com/jfelchner/ruby-progressbar',

--- a/ruby-progressbar.gemspec
+++ b/ruby-progressbar.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata      = {
     'allowed_push_host' => 'https://rubygems.org',
     'bug_tracker_uri'   => 'https://github.com/jfelchner/ruby-progressbar/issues',
-    'changelog_uri'     => 'https://github.com/jfelchner/ruby-progressbar/CHANGELOG.md',
+    'changelog_uri'     => 'https://github.com/jfelchner/ruby-progressbar/blob/master/CHANGELOG.md',
     'documentation_uri' => "https://github.com/jfelchner/ruby-progressbar/tree/releases/v#{ProgressBar::VERSION}",
     'homepage_uri'      => 'https://github.com/jfelchner/ruby-progressbar',
     'source_code_uri'   => 'https://github.com/jfelchner/ruby-progressbar',


### PR DESCRIPTION
Alternative would be to use "https://github.com/jfelchner/ruby-progressbar/blob/releases/v#{ProgressBar::VERSION}/CHANGELOG.md", but that would make it impossible to get updated changelog entries from master