### PR TITLE
CI: add Ruby 3.1 and 3.2 to the test matrix

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,6 @@
 ---
 
-name:                             "Build"
+name:                             "Linting"
 
 on:
   - "push"
@@ -45,7 +45,7 @@ jobs:
           fetch-depth:            0
 
       - name:                     "Build Ruby"
-        uses:                     "actions/setup-ruby@v1"
+        uses:                     "ruby/setup-ruby@v1"
         with:
           ruby-version:           2.7
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,6 +4,7 @@ name:                             "Build"
 
 on:
   - "push"
+  - "pull_request"
 
 jobs:
   test:
@@ -20,7 +21,9 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - '3.0'
+          - 3.1
+          - 3.2
           - ruby-head
         include:
           - ruby:                 2.1

--- a/gemfiles/v2/Gemfile.lock
+++ b/gemfiles/v2/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       fuubar (~> 2.0)
       rspec (~> 3.1)
     ruby-prof (0.15.9)
-    timecop (0.6.0)
+    timecop (0.9.6)
 
 PLATFORMS
   x86_64-darwin-19
@@ -41,7 +41,7 @@ DEPENDENCIES
   rspectacular (~> 0.70.6)
   ruby-prof (~> 0.15.8)
   ruby-progressbar!
-  timecop (= 0.6.0)
+  timecop (~> 0.6)
 
 BUNDLED WITH
    2.2.3

--- a/gemfiles/v2/ruby-progressbar.gemspec
+++ b/gemfiles/v2/ruby-progressbar.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec',          ["~> 3.7"]
   spec.add_development_dependency 'rspectacular',   ["~> 0.70.6"]
   spec.add_development_dependency 'fuubar',         ["~> 2.3"]
-  spec.add_development_dependency 'timecop',        ["= 0.6.0"]
+  spec.add_development_dependency 'timecop',        ["~> 0.6"]
 end

--- a/lib/ruby-progressbar/calculators/length.rb
+++ b/lib/ruby-progressbar/calculators/length.rb
@@ -50,7 +50,6 @@ class   Length
   end
   # rubocop:enable Style/RescueStandardError
 
-  # rubocop:disable Lint/DuplicateMethods
   begin
     require 'io/console'
 
@@ -68,7 +67,6 @@ class   Length
       dynamic_width_via_system_calls
     end
   end
-  # rubocop:enable Lint/DuplicateMethods
 
   def dynamic_width_via_output_stream_object
     _rows, columns = output.winsize

--- a/lib/ruby-progressbar/time.rb
+++ b/lib/ruby-progressbar/time.rb
@@ -17,11 +17,9 @@ class   Time
   end
 
   def unmocked_time_method
-    @unmocked_time_method ||= begin
-                                TIME_MOCKING_LIBRARY_METHODS.find do |method|
-                                  time.respond_to? method
-                                end
-                              end
+    @unmocked_time_method ||= TIME_MOCKING_LIBRARY_METHODS.find do |method|
+      time.respond_to? method
+    end
   end
 
   protected


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it to the build matrix. 