### PR TITLE
Add: Ability To Allow Different Projectors To Be Used For Time Estimates

### DIFF
--- a/lib/ruby-progressbar/base.rb
+++ b/lib/ruby-progressbar/base.rb
@@ -32,7 +32,20 @@ class   Base
     self.finished     = false
 
     self.timer        = Timer.new(options)
-    self.projector    = Calculators::SmoothedAverage.new(:strength => options[:smoothing])
+    projector_opts    = if options[:projector]
+                          options[:projector]
+                        elsif options[:smoothing]
+                          warn "WARNING: Passing the 'smoothing' option is deprecated " \
+                               "and will be removed in version 2.0. Please pass " \
+                               "{ projector: { type: 'smoothing', strength: 0.x }}. " \
+                               "For more information on why this change is happening, " \
+                               "visit https://github.com/jfelchner/ruby-progressbar/wiki/Upgrading"
+
+                          { :strength => options[:smoothing] }
+                        else
+                          {}
+                        end
+    self.projector    = Calculators::SmoothedAverage.new(projector_opts)
     self.progressable = Progress.new(options.merge(:projector => projector))
 
     options = options.merge(:progress  => progressable,

--- a/lib/ruby-progressbar/base.rb
+++ b/lib/ruby-progressbar/base.rb
@@ -46,7 +46,7 @@ class   Base
                           {}
                         end
     self.projector    = Calculators::SmoothedAverage.new(projector_opts)
-    self.progressable = Progress.new(options.merge(:projector => projector))
+    self.progressable = Progress.new(options)
 
     options = options.merge(:progress  => progressable,
                             :projector => projector,

--- a/lib/ruby-progressbar/base.rb
+++ b/lib/ruby-progressbar/base.rb
@@ -95,6 +95,7 @@ class   Base
     output.with_refresh do
       self.finished = false
       progressable.reset
+      projector.reset
       timer.reset
     end
   end
@@ -205,6 +206,7 @@ class   Base
   def update_progress(*args)
     output.with_refresh do
       progressable.__send__(*args)
+      projector.__send__(*args)
       timer.stop if finished?
     end
   end

--- a/lib/ruby-progressbar/base.rb
+++ b/lib/ruby-progressbar/base.rb
@@ -1,5 +1,6 @@
 require 'forwardable'
 
+require 'ruby-progressbar/calculators/smoothed_average'
 require 'ruby-progressbar/components/bar'
 require 'ruby-progressbar/components/percentage'
 require 'ruby-progressbar/components/rate'
@@ -31,10 +32,12 @@ class   Base
     self.finished     = false
 
     self.timer        = Timer.new(options)
-    self.progressable = Progress.new(options)
+    self.projector    = Calculators::SmoothedAverage.new(:strength => options[:smoothing])
+    self.progressable = Progress.new(options.merge(:projector => projector))
 
-    options = options.merge(:progress => progressable,
-                            :timer    => timer)
+    options = options.merge(:progress  => progressable,
+                            :projector => projector,
+                            :timer     => timer)
 
     self.title_component      = Components::Title.new(options)
     self.bar_component        = Components::Bar.new(options)
@@ -174,6 +177,7 @@ class   Base
   protected
 
   attr_accessor :output,
+                :projector,
                 :timer,
                 :progressable,
                 :title_component,

--- a/lib/ruby-progressbar/calculators/smoothed_average.rb
+++ b/lib/ruby-progressbar/calculators/smoothed_average.rb
@@ -19,7 +19,10 @@ class   SmoothedAverage
   def increment; end
   def progress=(_new_progress); end
   def total=(_new_total); end
-  def reset; end
+
+  def reset
+    start
+  end
 
   def calculate(new_value)
     self.projection = \
@@ -28,6 +31,10 @@ class   SmoothedAverage
         new_value,
         strength
       )
+  end
+
+  def none?
+    projection.zero?
   end
 
   def self.calculate(current_projection, new_value, rate)

--- a/lib/ruby-progressbar/calculators/smoothed_average.rb
+++ b/lib/ruby-progressbar/calculators/smoothed_average.rb
@@ -1,27 +1,47 @@
 class   ProgressBar
 module  Calculators
 class   SmoothedAverage
-  DEFAULT_STRENGTH = 0.1
+  DEFAULT_STRENGTH           = 0.1
+  DEFAULT_BEGINNING_POSITION = 0
 
-  attr_accessor :strength
+  attr_accessor :samples,
+                :strength
   attr_reader   :projection
 
   def initialize(options = {})
+    self.samples    = []
     self.projection = 0.0
     self.strength   = options[:strength] || DEFAULT_STRENGTH
+
+    start(:at => DEFAULT_BEGINNING_POSITION)
   end
 
-  def start(_options = {})
+  def start(options = {})
     self.projection = 0.0
+    self.progress   = samples[0] = (options[:at] || progress)
   end
 
-  def decrement; end
-  def increment; end
-  def progress=(_new_progress); end
+  def decrement
+    self.progress -= 1
+  end
+
+  def increment
+    self.progress += 1
+  end
+
+  def progress
+    samples[1]
+  end
+
+  def progress=(new_progress)
+    samples[1] = new_progress
+    calculate(absolute)
+  end
+
   def total=(_new_total); end
 
   def reset
-    start
+    start(:at => samples[0])
   end
 
   def calculate(new_value)
@@ -44,6 +64,12 @@ class   SmoothedAverage
   protected
 
   attr_writer :projection
+
+  private
+
+  def absolute
+    samples[1] - samples[0]
+  end
 end
 end
 end

--- a/lib/ruby-progressbar/calculators/smoothed_average.rb
+++ b/lib/ruby-progressbar/calculators/smoothed_average.rb
@@ -15,6 +15,12 @@ class   SmoothedAverage
     self.projection = 0.0
   end
 
+  def decrement; end
+  def increment; end
+  def progress=(_new_progress); end
+  def total=(_new_total); end
+  def reset; end
+
   def calculate(new_value)
     self.projection = \
       self.class.calculate(

--- a/lib/ruby-progressbar/calculators/smoothed_average.rb
+++ b/lib/ruby-progressbar/calculators/smoothed_average.rb
@@ -1,8 +1,24 @@
 class   ProgressBar
 module  Calculators
 class   SmoothedAverage
-  def self.calculate(current_average, new_value_to_average, rate)
-    (new_value_to_average * (1.0 - rate)) + (current_average * rate)
+  DEFAULT_STRENGTH = 0.1
+
+  attr_accessor :strength
+
+  def initialize(options = {})
+    self.strength = options[:strength] || DEFAULT_STRENGTH
+  end
+
+  def calculate(current_projection, new_value)
+    self.class.calculate(
+      current_projection,
+      new_value,
+      strength
+    )
+  end
+
+  def self.calculate(current_projection, new_value, rate)
+    (new_value * (1.0 - rate)) + (current_projection * rate)
   end
 end
 end

--- a/lib/ruby-progressbar/calculators/smoothed_average.rb
+++ b/lib/ruby-progressbar/calculators/smoothed_average.rb
@@ -4,22 +4,33 @@ class   SmoothedAverage
   DEFAULT_STRENGTH = 0.1
 
   attr_accessor :strength
+  attr_reader   :projection
 
   def initialize(options = {})
-    self.strength = options[:strength] || DEFAULT_STRENGTH
+    self.projection = 0.0
+    self.strength   = options[:strength] || DEFAULT_STRENGTH
   end
 
-  def calculate(current_projection, new_value)
-    self.class.calculate(
-      current_projection,
-      new_value,
-      strength
-    )
+  def start(_options = {})
+    self.projection = 0.0
+  end
+
+  def calculate(new_value)
+    self.projection = \
+      self.class.calculate(
+        @projection,
+        new_value,
+        strength
+      )
   end
 
   def self.calculate(current_projection, new_value, rate)
     (new_value * (1.0 - rate)) + (current_projection * rate)
   end
+
+  protected
+
+  attr_writer :projection
 end
 end
 end

--- a/lib/ruby-progressbar/calculators/smoothed_average.rb
+++ b/lib/ruby-progressbar/calculators/smoothed_average.rb
@@ -33,22 +33,18 @@ class   SmoothedAverage
     samples[1]
   end
 
-  def progress=(new_progress)
-    samples[1] = new_progress
-    calculate(absolute)
-  end
-
   def total=(_new_total); end
 
   def reset
     start(:at => samples[0])
   end
 
-  def calculate(new_value)
+  def progress=(new_progress)
+    samples[1] = new_progress
     self.projection = \
       self.class.calculate(
         @projection,
-        new_value,
+        absolute,
         strength
       )
   end

--- a/lib/ruby-progressbar/components/time.rb
+++ b/lib/ruby-progressbar/components/time.rb
@@ -19,8 +19,9 @@ class   Time
   }.freeze
 
   def initialize(options = {})
-    self.timer    = options[:timer]
-    self.progress = options[:progress]
+    self.timer     = options[:timer]
+    self.progress  = options[:progress]
+    self.projector = options[:projector]
   end
 
   def estimated_with_label(out_of_bounds_time_format = nil)
@@ -57,7 +58,8 @@ class   Time
   protected
 
   attr_accessor :timer,
-                :progress
+                :progress,
+                :projector
 
   private
 
@@ -90,9 +92,9 @@ class   Time
   end
 
   def estimated_seconds_remaining
-    return if progress.unknown? || progress.none? || timer.stopped? || timer.reset?
+    return if progress.unknown? || projector.none? || progress.none? || timer.stopped? || timer.reset?
 
-    (timer.elapsed_seconds * ((progress.total / progress.running_average) - 1)).round
+    (timer.elapsed_seconds * ((progress.total / projector.projection) - 1)).round
   end
 end
 end

--- a/lib/ruby-progressbar/progress.rb
+++ b/lib/ruby-progressbar/progress.rb
@@ -92,7 +92,7 @@ class   Progress
   end
 
   def none?
-    running_average.zero? || progress.zero?
+    progress.zero?
   end
 
   def unknown?

--- a/lib/ruby-progressbar/progress.rb
+++ b/lib/ruby-progressbar/progress.rb
@@ -1,33 +1,20 @@
 require 'ruby-progressbar/errors/invalid_progress_error'
-require 'ruby-progressbar/calculators/smoothed_average'
 
 class   ProgressBar
 class   Progress
-  DEFAULT_TOTAL                      = 100
-  DEFAULT_BEGINNING_POSITION         = 0
-  DEFAULT_RUNNING_AVERAGE_RATE       = 0.1
-  DEFAULT_RUNNING_AVERAGE_CALCULATOR = ProgressBar::Calculators::SmoothedAverage
-
-  RUNNING_AVERAGE_CALCULATOR_MAP     = {
-    'smoothing' => ProgressBar::Calculators::SmoothedAverage
-  }.freeze
+  DEFAULT_TOTAL              = 100
+  DEFAULT_BEGINNING_POSITION = 0
 
   attr_reader               :total,
                             :progress
 
   attr_accessor             :starting_position,
                             :running_average,
-                            :running_average_calculator,
-                            :running_average_rate
+                            :running_average_calculator
 
   def initialize(options = {})
     self.total                      = options.fetch(:total, DEFAULT_TOTAL)
-    self.running_average_rate       = options[:smoothing] ||
-                                      options[:running_average_rate] ||
-                                      DEFAULT_RUNNING_AVERAGE_RATE
-    self.running_average_calculator = RUNNING_AVERAGE_CALCULATOR_MAP.
-                                        fetch(options[:running_average_calculator],
-                                              DEFAULT_RUNNING_AVERAGE_CALCULATOR)
+    self.running_average_calculator = options[:projector]
 
     start :at => DEFAULT_BEGINNING_POSITION
   end
@@ -79,8 +66,7 @@ class   Progress
     @progress = new_progress
 
     self.running_average = running_average_calculator.calculate(running_average,
-                                                                absolute,
-                                                                running_average_rate)
+                                                                absolute)
   end
 
   def total=(new_total)

--- a/lib/ruby-progressbar/progress.rb
+++ b/lib/ruby-progressbar/progress.rb
@@ -7,13 +7,10 @@ class   Progress
 
   attr_reader               :total,
                             :progress
-
-  attr_accessor             :starting_position,
-                            :running_average_calculator
+  attr_accessor             :starting_position
 
   def initialize(options = {})
-    self.total                      = options.fetch(:total, DEFAULT_TOTAL)
-    self.running_average_calculator = options[:projector]
+    self.total = options.fetch(:total, DEFAULT_TOTAL)
 
     start(:at => DEFAULT_BEGINNING_POSITION)
   end
@@ -62,10 +59,6 @@ class   Progress
     end
 
     @progress = new_progress
-  end
-
-  def running_average
-    running_average_calculator.projection
   end
 
   def total=(new_total)

--- a/lib/ruby-progressbar/progress.rb
+++ b/lib/ruby-progressbar/progress.rb
@@ -19,7 +19,6 @@ class   Progress
   end
 
   def start(options = {})
-    running_average_calculator.start
     self.progress = \
       self.starting_position = options[:at] || progress
   end

--- a/lib/ruby-progressbar/progress.rb
+++ b/lib/ruby-progressbar/progress.rb
@@ -62,7 +62,6 @@ class   Progress
     end
 
     @progress = new_progress
-    running_average_calculator.calculate(absolute)
   end
 
   def running_average

--- a/lib/ruby-progressbar/progress.rb
+++ b/lib/ruby-progressbar/progress.rb
@@ -9,19 +9,18 @@ class   Progress
                             :progress
 
   attr_accessor             :starting_position,
-                            :running_average,
                             :running_average_calculator
 
   def initialize(options = {})
     self.total                      = options.fetch(:total, DEFAULT_TOTAL)
     self.running_average_calculator = options[:projector]
 
-    start :at => DEFAULT_BEGINNING_POSITION
+    start(:at => DEFAULT_BEGINNING_POSITION)
   end
 
   def start(options = {})
-    self.running_average   = 0
-    self.progress          = \
+    running_average_calculator.start
+    self.progress = \
       self.starting_position = options[:at] || progress
   end
 
@@ -54,7 +53,7 @@ class   Progress
   end
 
   def reset
-    start :at => starting_position
+    start(:at => starting_position)
   end
 
   def progress=(new_progress)
@@ -64,9 +63,11 @@ class   Progress
     end
 
     @progress = new_progress
+    running_average_calculator.calculate(absolute)
+  end
 
-    self.running_average = running_average_calculator.calculate(running_average,
-                                                                absolute)
+  def running_average
+    running_average_calculator.projection
   end
 
   def total=(new_total)

--- a/lib/ruby-progressbar/projector.rb
+++ b/lib/ruby-progressbar/projector.rb
@@ -1,10 +1,10 @@
-require 'ruby-progressbar/calculators/smoothed_average'
+require 'ruby-progressbar/projectors/smoothed_average'
 
 class   ProgressBar
 class   Projector
-  DEFAULT_PROJECTOR     = ProgressBar::Calculators::SmoothedAverage
+  DEFAULT_PROJECTOR     = ProgressBar::Projectors::SmoothedAverage
   NAME_TO_PROJECTOR_MAP = {
-    'smoothed' => ProgressBar::Calculators::SmoothedAverage
+    'smoothed' => ProgressBar::Projectors::SmoothedAverage
   }.freeze
 
   def self.from_type(name)

--- a/lib/ruby-progressbar/projector.rb
+++ b/lib/ruby-progressbar/projector.rb
@@ -1,0 +1,14 @@
+require 'ruby-progressbar/calculators/smoothed_average'
+
+class   ProgressBar
+class   Projector
+  DEFAULT_PROJECTOR     = ProgressBar::Calculators::SmoothedAverage
+  NAME_TO_PROJECTOR_MAP = {
+    'smoothed' => ProgressBar::Calculators::SmoothedAverage
+  }.freeze
+
+  def self.from_type(name)
+    NAME_TO_PROJECTOR_MAP.fetch(name, DEFAULT_PROJECTOR)
+  end
+end
+end

--- a/lib/ruby-progressbar/projectors/smoothed_average.rb
+++ b/lib/ruby-progressbar/projectors/smoothed_average.rb
@@ -1,5 +1,5 @@
 class   ProgressBar
-module  Calculators
+module  Projectors
 class   SmoothedAverage
   DEFAULT_STRENGTH           = 0.1
   DEFAULT_BEGINNING_POSITION = 0

--- a/spec/lib/ruby-progressbar/base_spec.rb
+++ b/spec/lib/ruby-progressbar/base_spec.rb
@@ -232,7 +232,7 @@ describe Base do
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0))
 
       progressbar = ProgressBar::Base.new(:output    => output,
-                                          :smoothing => 0.0,
+                                          :projector => { :strength => 0.0 },
                                           :total     => 100,
                                           :format    => '%l')
 
@@ -251,7 +251,7 @@ describe Base do
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0))
 
       progressbar = ProgressBar::Base.new(:output    => output,
-                                          :smoothing => 0.0,
+                                          :projector => { :strength => 0.0 },
                                           :total     => 100,
                                           :format    => '%l')
 
@@ -274,6 +274,32 @@ describe Base do
       expect { progressbar.stop }.
         not_to raise_error
     end
+
+    # rubocop:disable RSpec/AnyInstance
+    it 'displays a warning if the user passes the deprecated "smoothing" option but ' \
+       'still processes it' do
+      expect_any_instance_of(ProgressBar::Base).
+        to receive(:warn).
+        with(include("WARNING: Passing the 'smoothing' option is deprecated"))
+
+      Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0))
+
+      progressbar = ProgressBar::Base.new(:output    => output,
+                                          :smoothing => 0.0,
+                                          :total     => 100,
+                                          :format    => '%l')
+
+      progressbar.progress += 50
+
+      Timecop.freeze(::Time.utc(2020, 1, 1, 0, 30, 0))
+
+      progressbar.finish
+
+      Timecop.return
+
+      expect(progressbar.to_s).to eql '00:30:00'
+    end
+    # rubocop:enable RSpec/AnyInstance
 
     it 'appends proper ending to string for non-TTY devices' do
       progressbar = ProgressBar::Base.new(:output => non_tty_output)

--- a/spec/lib/ruby-progressbar/calculators/smoothed_average_spec.rb
+++ b/spec/lib/ruby-progressbar/calculators/smoothed_average_spec.rb
@@ -41,6 +41,19 @@ describe SmoothedAverage do
 
       expect(projector.projection).to be 0.0
     end
+
+    it 'resets based on the starting position' do
+      projector = SmoothedAverage.new(:strength => 0.1)
+      projector.start(:at => 10)
+      projector.progress = 20
+
+      expect(projector.projection).not_to be_zero
+
+      projector.reset
+      projector.progress = 20
+
+      expect(projector.projection).to be 9.0
+    end
   end
 
   describe '#strength' do

--- a/spec/lib/ruby-progressbar/calculators/smoothed_average_spec.rb
+++ b/spec/lib/ruby-progressbar/calculators/smoothed_average_spec.rb
@@ -4,7 +4,7 @@ require 'ruby-progressbar/calculators/smoothed_average'
 class    ProgressBar
 module   Calculators
 describe SmoothedAverage do
-  it 'can properly calculate a projector' do
+  it 'can properly calculate a projection' do
     first_projection = SmoothedAverage.calculate(4.5,  12,  0.1)
     expect(first_projection).to be_within(0.001).of 11.25
 
@@ -13,6 +13,20 @@ describe SmoothedAverage do
 
     third_projection = SmoothedAverage.calculate(41.8, 100, 0.59)
     expect(third_projection).to be_within(0.001).of 65.662
+  end
+
+  describe '#start' do
+    it 'resets the projection' do
+      projector = SmoothedAverage.new
+      projector.start
+      projector.calculate(10)
+
+      expect(projector.projection).not_to be_zero
+
+      projector.start
+
+      expect(projector.projection).to be 0.0
+    end
   end
 
   describe '#strength' do

--- a/spec/lib/ruby-progressbar/calculators/smoothed_average_spec.rb
+++ b/spec/lib/ruby-progressbar/calculators/smoothed_average_spec.rb
@@ -4,15 +4,54 @@ require 'ruby-progressbar/calculators/smoothed_average'
 class    ProgressBar
 module   Calculators
 describe SmoothedAverage do
-  it 'can properly calculate a projection' do
-    first_projection = SmoothedAverage.calculate(4.5,  12,  0.1)
-    expect(first_projection).to be_within(0.001).of 11.25
+  describe '.calculate' do
+    it 'can properly calculate a projection' do
+      first_projection = SmoothedAverage.calculate(4.5,  12,  0.1)
+      expect(first_projection).to be_within(0.001).of 11.25
 
-    second_projection = SmoothedAverage.calculate(8.2,  51,  0.7)
-    expect(second_projection).to be_within(0.001).of 21.04
+      second_projection = SmoothedAverage.calculate(8.2,  51,  0.7)
+      expect(second_projection).to be_within(0.001).of 21.04
 
-    third_projection = SmoothedAverage.calculate(41.8, 100, 0.59)
-    expect(third_projection).to be_within(0.001).of 65.662
+      third_projection = SmoothedAverage.calculate(41.8, 100, 0.59)
+      expect(third_projection).to be_within(0.001).of 65.662
+    end
+  end
+
+  describe '#projection' do
+    it 'can properly calculate a running average' do
+      projector = SmoothedAverage.new(:strength => 0.1)
+      projector.start
+      projector.progress = 5
+      projector.progress = 12
+
+      expect(projector.projection).to be_within(0.001).of 11.25
+    end
+
+    it 'knows the running average even when progress has been made' do
+      projector = SmoothedAverage.new(:total => 50)
+
+      projector.instance_variable_set(:@projection, 10)
+      projector.start :at => 0
+
+      expect(projector.projection).to be_zero
+
+      projector.progress += 40
+
+      expect(projector.projection).to be 36.0
+    end
+
+    it 'knows the running average is reset even after progress is started' do
+      projector = SmoothedAverage.new(:total => 50)
+
+      projector.instance_variable_set(:@projection, 10)
+      projector.start :at => 0
+
+      expect(projector.projection).to be_zero
+
+      projector.start :at => 40
+
+      expect(projector.projection).to be 0.0
+    end
   end
 
   describe '#start' do

--- a/spec/lib/ruby-progressbar/calculators/smoothed_average_spec.rb
+++ b/spec/lib/ruby-progressbar/calculators/smoothed_average_spec.rb
@@ -4,15 +4,27 @@ require 'ruby-progressbar/calculators/smoothed_average'
 class    ProgressBar
 module   Calculators
 describe SmoothedAverage do
-  it 'can properly calculate a running average' do
-    first_average = SmoothedAverage.calculate(4.5,  12,  0.1)
-    expect(first_average).to be_within(0.001).of 11.25
+  it 'can properly calculate a projector' do
+    first_projection = SmoothedAverage.calculate(4.5,  12,  0.1)
+    expect(first_projection).to be_within(0.001).of 11.25
 
-    second_average = SmoothedAverage.calculate(8.2,  51,  0.7)
-    expect(second_average).to be_within(0.001).of 21.04
+    second_projection = SmoothedAverage.calculate(8.2,  51,  0.7)
+    expect(second_projection).to be_within(0.001).of 21.04
 
-    third_average = SmoothedAverage.calculate(41.8, 100, 0.59)
-    expect(third_average).to be_within(0.001).of 65.662
+    third_projection = SmoothedAverage.calculate(41.8, 100, 0.59)
+    expect(third_projection).to be_within(0.001).of 65.662
+  end
+
+  describe '#strength' do
+    it 'allows the default strength to be overridden' do
+      projector = SmoothedAverage.new(:strength => 0.3)
+
+      expect(projector.strength).to be 0.3
+    end
+
+    it 'has a default strength' do
+      expect(SmoothedAverage.new.strength).to be 0.1
+    end
   end
 end
 end

--- a/spec/lib/ruby-progressbar/calculators/smoothed_average_spec.rb
+++ b/spec/lib/ruby-progressbar/calculators/smoothed_average_spec.rb
@@ -29,6 +29,20 @@ describe SmoothedAverage do
     end
   end
 
+  describe '#reset' do
+    it 'resets the projection' do
+      projector = SmoothedAverage.new
+      projector.start
+      projector.calculate(10)
+
+      expect(projector.projection).not_to be_zero
+
+      projector.reset
+
+      expect(projector.projection).to be 0.0
+    end
+  end
+
   describe '#strength' do
     it 'allows the default strength to be overridden' do
       projector = SmoothedAverage.new(:strength => 0.3)

--- a/spec/lib/ruby-progressbar/calculators/smoothed_average_spec.rb
+++ b/spec/lib/ruby-progressbar/calculators/smoothed_average_spec.rb
@@ -19,7 +19,7 @@ describe SmoothedAverage do
     it 'resets the projection' do
       projector = SmoothedAverage.new
       projector.start
-      projector.calculate(10)
+      projector.progress = 10
 
       expect(projector.projection).not_to be_zero
 
@@ -33,7 +33,7 @@ describe SmoothedAverage do
     it 'resets the projection' do
       projector = SmoothedAverage.new
       projector.start
-      projector.calculate(10)
+      projector.progress = 10
 
       expect(projector.projection).not_to be_zero
 

--- a/spec/lib/ruby-progressbar/components/bar_spec.rb
+++ b/spec/lib/ruby-progressbar/components/bar_spec.rb
@@ -30,7 +30,8 @@ describe Bar do
 
   describe '#bar' do
     it 'displays the bar with no indication of progress when just begun' do
-      progress    = Progress.new(:total => 50)
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 50)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
 
@@ -40,9 +41,10 @@ describe Bar do
 
     it 'displays the bar with an indication of progress when nothing has been ' \
        'completed and the bar is incremented' do
-      progress    = Progress.new :total    => 50
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 50)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
       progress.increment
 
       bar_text = progressbar.bar(100)
@@ -51,9 +53,10 @@ describe Bar do
 
     it 'displays the bar with no indication of progress when a fraction of a percentage ' \
        'has been completed' do
-      progress    = Progress.new :total    => 200
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 200)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
       progress.start :at => 1
 
       bar_text = progressbar.bar(100)
@@ -61,9 +64,10 @@ describe Bar do
     end
 
     it 'displays the bar as 100% complete when completed' do
-      progress    = Progress.new :total    => 50
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 50)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
       progress.start :at => 50
       progress.increment
 
@@ -72,9 +76,10 @@ describe Bar do
     end
 
     it 'displays the bar as 98% complete when completed and the bar is decremented' do
-      progress    = Progress.new :total    => 50
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 50)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
       progress.start :at => 50
       progress.decrement
 
@@ -85,9 +90,10 @@ describe Bar do
 
   describe '#bar_with_percentage' do
     it 'displays the bar with an integrated percentage properly when empty' do
-      progress    = Progress.new :total    => 100
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 100)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
 
       bar_text = progressbar.bar_with_percentage(100)
       expect(bar_text).to eql ''
@@ -95,9 +101,10 @@ describe Bar do
 
     it 'displays the bar with an integrated percentage properly just before' \
        'the percentage is displayed' do
-      progress    = Progress.new :total    => 100
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 100)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
 
       4.times { progress.increment }
 
@@ -107,9 +114,10 @@ describe Bar do
 
     it 'displays the bar with an integrated percentage properly immediately after' \
        'the percentage is displayed' do
-      progress    = Progress.new :total    => 100
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 100)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
 
       5.times { progress.increment }
 
@@ -119,9 +127,10 @@ describe Bar do
 
     it 'displays the bar with an integrated percentage properly on double digit' \
        'percentage' do
-      progress    = Progress.new :total    => 100
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 100)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
 
       10.times { progress.increment }
 
@@ -130,9 +139,10 @@ describe Bar do
     end
 
     it 'displays the bar with an integrated percentage properly when finished' do
-      progress    = Progress.new :total    => 100
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 100)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
       progress.finish
 
       bar_text = progressbar.bar_with_percentage(100)
@@ -141,9 +151,10 @@ describe Bar do
 
     it 'calculates the remaining negative space properly with an integrated percentage ' \
        'bar of 0 percent' do
-      progress    = Progress.new :total    => 200
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 200)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
 
       bar_text = progressbar.bar_with_percentage(100)
       expect(bar_text).to eql ''
@@ -162,9 +173,10 @@ describe Bar do
 
   describe '#incomplete_space' do
     it 'displays the bar with an integrated percentage properly when empty' do
-      progress    = Progress.new :total    => 100
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 100)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
 
       bar_text = progressbar.incomplete_space(100)
       expect(bar_text).to eql ' ' * 100
@@ -172,9 +184,10 @@ describe Bar do
 
     it 'displays the bar with an integrated percentage properly just before' \
        'the percentage is displayed' do
-      progress    = Progress.new :total    => 100
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 100)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
 
       4.times { progress.increment }
 
@@ -184,9 +197,10 @@ describe Bar do
 
     it 'displays the bar with an integrated percentage properly immediately after' \
        'the percentage is displayed' do
-      progress    = Progress.new :total    => 100
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 100)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
 
       5.times { progress.increment }
 
@@ -196,9 +210,10 @@ describe Bar do
 
     it 'displays the bar with an integrated percentage properly on double digit' \
        'percentage' do
-      progress    = Progress.new :total    => 100
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 100)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
 
       10.times { progress.increment }
 
@@ -207,9 +222,10 @@ describe Bar do
     end
 
     it 'displays the bar with an integrated percentage properly when finished' do
-      progress    = Progress.new :total    => 100
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 100)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
       progress.finish
 
       bar_text = progressbar.incomplete_space(100)
@@ -218,9 +234,10 @@ describe Bar do
 
     it 'calculates the remaining negative space properly with an integrated percentage ' \
        'bar of 0 percent' do
-      progress    = Progress.new :total    => 200
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 100
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => 200)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 100)
 
       bar_text = progressbar.incomplete_space(100)
       expect(bar_text).to eql ' ' * 100
@@ -237,9 +254,10 @@ describe Bar do
     end
 
     it 'is represented correctly when a bar has an unknown amount to completion' do
-      progress    = Progress.new :total    => nil
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 80
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => nil)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 80)
 
       bar_text = progressbar.incomplete_space(80)
       expect(bar_text).to eql('=---' * 20)
@@ -247,9 +265,10 @@ describe Bar do
 
     it 'is represented after being incremented once when a bar has an unknown amount ' \
        'to completion' do
-      progress    = Progress.new :total    => nil
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 80
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => nil)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 80)
 
       progress.increment
 
@@ -259,9 +278,10 @@ describe Bar do
 
     it 'is represented after being incremented twice when a bar has an unknown amount ' \
        'to completion' do
-      progress    = Progress.new :total    => nil
-      progressbar = Bar.new      :progress => progress,
-                                 :length   => 80
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => nil)
+      progressbar = Bar.new(:progress => progress,
+                            :length   => 80)
 
       2.times { progress.increment }
 
@@ -270,14 +290,15 @@ describe Bar do
     end
 
     it 'is represented correctly when a bar has a customized unknown animation' do
-      progress    = Progress.new :total                            => nil
-      progressbar = Bar.new      :progress                         => progress,
-                                 :unknown_progress_animation_steps => [
-                                                                        '*--',
-                                                                        '-*-',
-                                                                        '--*'
-                                                                      ],
-                                 :length                           => 80
+      projector   = Calculators::SmoothedAverage.new
+      progress    = Progress.new(:projector => projector, :total => nil)
+      progressbar = Bar.new(:progress                         => progress,
+                            :unknown_progress_animation_steps => [
+                                                                   '*--',
+                                                                   '-*-',
+                                                                   '--*'
+                                                                 ],
+                            :length                           => 80)
 
       bar_text = progressbar.incomplete_space(80)
       expect(bar_text).to eql("#{'*--' * 26}*-")
@@ -286,8 +307,9 @@ describe Bar do
 
   it 'raises an error when attempting to set the current value of the bar to be ' \
      'greater than the total' do
-    progress     = Progress.new :total    => 10
-    _progressbar = Bar.new      :progress => progress
+    projector    = Calculators::SmoothedAverage.new
+    progress     = Progress.new(:projector => projector, :total => 10)
+    _progressbar = Bar.new(:progress => progress)
 
     expect { progress.start :at => 11 }.
       to \

--- a/spec/lib/ruby-progressbar/components/bar_spec.rb
+++ b/spec/lib/ruby-progressbar/components/bar_spec.rb
@@ -30,7 +30,7 @@ describe Bar do
 
   describe '#bar' do
     it 'displays the bar with no indication of progress when just begun' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 50)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -41,7 +41,7 @@ describe Bar do
 
     it 'displays the bar with an indication of progress when nothing has been ' \
        'completed and the bar is incremented' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 50)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -53,7 +53,7 @@ describe Bar do
 
     it 'displays the bar with no indication of progress when a fraction of a percentage ' \
        'has been completed' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 200)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -64,7 +64,7 @@ describe Bar do
     end
 
     it 'displays the bar as 100% complete when completed' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 50)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -76,7 +76,7 @@ describe Bar do
     end
 
     it 'displays the bar as 98% complete when completed and the bar is decremented' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 50)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -90,7 +90,7 @@ describe Bar do
 
   describe '#bar_with_percentage' do
     it 'displays the bar with an integrated percentage properly when empty' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 100)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -101,7 +101,7 @@ describe Bar do
 
     it 'displays the bar with an integrated percentage properly just before' \
        'the percentage is displayed' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 100)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -114,7 +114,7 @@ describe Bar do
 
     it 'displays the bar with an integrated percentage properly immediately after' \
        'the percentage is displayed' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 100)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -127,7 +127,7 @@ describe Bar do
 
     it 'displays the bar with an integrated percentage properly on double digit' \
        'percentage' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 100)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -139,7 +139,7 @@ describe Bar do
     end
 
     it 'displays the bar with an integrated percentage properly when finished' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 100)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -151,7 +151,7 @@ describe Bar do
 
     it 'calculates the remaining negative space properly with an integrated percentage ' \
        'bar of 0 percent' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 200)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -173,7 +173,7 @@ describe Bar do
 
   describe '#incomplete_space' do
     it 'displays the bar with an integrated percentage properly when empty' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 100)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -184,7 +184,7 @@ describe Bar do
 
     it 'displays the bar with an integrated percentage properly just before' \
        'the percentage is displayed' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 100)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -197,7 +197,7 @@ describe Bar do
 
     it 'displays the bar with an integrated percentage properly immediately after' \
        'the percentage is displayed' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 100)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -210,7 +210,7 @@ describe Bar do
 
     it 'displays the bar with an integrated percentage properly on double digit' \
        'percentage' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 100)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -222,7 +222,7 @@ describe Bar do
     end
 
     it 'displays the bar with an integrated percentage properly when finished' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 100)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -234,7 +234,7 @@ describe Bar do
 
     it 'calculates the remaining negative space properly with an integrated percentage ' \
        'bar of 0 percent' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => 200)
       progressbar = Bar.new(:progress => progress,
                             :length   => 100)
@@ -254,7 +254,7 @@ describe Bar do
     end
 
     it 'is represented correctly when a bar has an unknown amount to completion' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => nil)
       progressbar = Bar.new(:progress => progress,
                             :length   => 80)
@@ -265,7 +265,7 @@ describe Bar do
 
     it 'is represented after being incremented once when a bar has an unknown amount ' \
        'to completion' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => nil)
       progressbar = Bar.new(:progress => progress,
                             :length   => 80)
@@ -278,7 +278,7 @@ describe Bar do
 
     it 'is represented after being incremented twice when a bar has an unknown amount ' \
        'to completion' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => nil)
       progressbar = Bar.new(:progress => progress,
                             :length   => 80)
@@ -290,7 +290,7 @@ describe Bar do
     end
 
     it 'is represented correctly when a bar has a customized unknown animation' do
-      projector   = Calculators::SmoothedAverage.new
+      projector   = Projectors::SmoothedAverage.new
       progress    = Progress.new(:projector => projector, :total => nil)
       progressbar = Bar.new(:progress                         => progress,
                             :unknown_progress_animation_steps => [
@@ -307,7 +307,7 @@ describe Bar do
 
   it 'raises an error when attempting to set the current value of the bar to be ' \
      'greater than the total' do
-    projector    = Calculators::SmoothedAverage.new
+    projector    = Projectors::SmoothedAverage.new
     progress     = Progress.new(:projector => projector, :total => 10)
     _progressbar = Bar.new(:progress => progress)
 

--- a/spec/lib/ruby-progressbar/components/percentage_spec.rb
+++ b/spec/lib/ruby-progressbar/components/percentage_spec.rb
@@ -6,7 +6,8 @@ module   Components
 describe Percentage do
   describe '#percentage' do
     it 'returns the percentage' do
-      progress   = Progress.new(:total => 10)
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector, :total => 10)
       percentage = Percentage.new(:progress => progress)
 
       progress.progress = 5
@@ -17,7 +18,8 @@ describe Percentage do
 
   describe '#percentage_with_precision' do
     it 'returns the percentage' do
-      progress   = Progress.new(:total => 10)
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector, :total => 10)
       percentage = Percentage.new(:progress => progress)
 
       progress.progress = 5
@@ -28,7 +30,8 @@ describe Percentage do
 
   describe '#justified_percentage' do
     it 'returns the percentage' do
-      progress   = Progress.new(:total => 10)
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector, :total => 10)
       percentage = Percentage.new(:progress => progress)
 
       progress.progress = 5
@@ -39,7 +42,8 @@ describe Percentage do
 
   describe '#justified_percentage_with_precision' do
     it 'returns the percentage' do
-      progress   = Progress.new(:total => 10)
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector, :total => 10)
       percentage = Percentage.new(:progress => progress)
 
       progress.progress = 5

--- a/spec/lib/ruby-progressbar/components/percentage_spec.rb
+++ b/spec/lib/ruby-progressbar/components/percentage_spec.rb
@@ -6,7 +6,7 @@ module   Components
 describe Percentage do
   describe '#percentage' do
     it 'returns the percentage' do
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new(:projector => projector, :total => 10)
       percentage = Percentage.new(:progress => progress)
 
@@ -18,7 +18,7 @@ describe Percentage do
 
   describe '#percentage_with_precision' do
     it 'returns the percentage' do
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new(:projector => projector, :total => 10)
       percentage = Percentage.new(:progress => progress)
 
@@ -30,7 +30,7 @@ describe Percentage do
 
   describe '#justified_percentage' do
     it 'returns the percentage' do
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new(:projector => projector, :total => 10)
       percentage = Percentage.new(:progress => progress)
 
@@ -42,7 +42,7 @@ describe Percentage do
 
   describe '#justified_percentage_with_precision' do
     it 'returns the percentage' do
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new(:projector => projector, :total => 10)
       percentage = Percentage.new(:progress => progress)
 

--- a/spec/lib/ruby-progressbar/components/rate_spec.rb
+++ b/spec/lib/ruby-progressbar/components/rate_spec.rb
@@ -8,7 +8,7 @@ describe Rate do
     it 'returns the rate as a formatted integer' do
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0))
 
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new(:projector => projector, :total => 100)
       timer      = Timer.new
       rate       = Rate.new(:progress => progress,
@@ -29,7 +29,7 @@ describe Rate do
     it 'can scale the rate' do
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0))
 
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new(:projector => projector, :total => 100)
       timer      = Timer.new
       rate       = Rate.new(:progress   => progress,
@@ -53,7 +53,7 @@ describe Rate do
     it 'returns the rate as a formatted integer' do
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0))
 
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new(:projector => projector, :total => 100)
       timer      = Timer.new
       rate       = Rate.new(:progress => progress,

--- a/spec/lib/ruby-progressbar/components/rate_spec.rb
+++ b/spec/lib/ruby-progressbar/components/rate_spec.rb
@@ -8,10 +8,11 @@ describe Rate do
     it 'returns the rate as a formatted integer' do
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0))
 
-      progress = Progress.new(:total => 100)
-      timer    = Timer.new
-      rate     = Rate.new(:progress => progress,
-                          :timer    => timer)
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector, :total => 100)
+      timer      = Timer.new
+      rate       = Rate.new(:progress => progress,
+                            :timer    => timer)
 
       progress.start
       timer.start
@@ -28,11 +29,12 @@ describe Rate do
     it 'can scale the rate' do
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0))
 
-      progress = Progress.new(:total => 100)
-      timer    = Timer.new
-      rate     = Rate.new(:progress   => progress,
-                          :timer      => timer,
-                          :rate_scale => lambda { |x| x * 2 })
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector, :total => 100)
+      timer      = Timer.new
+      rate       = Rate.new(:progress   => progress,
+                            :timer      => timer,
+                            :rate_scale => lambda { |x| x * 2 })
 
       progress.start
       timer.start
@@ -51,10 +53,11 @@ describe Rate do
     it 'returns the rate as a formatted integer' do
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0))
 
-      progress = Progress.new(:total => 100)
-      timer    = Timer.new
-      rate     = Rate.new(:progress => progress,
-                          :timer    => timer)
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector, :total => 100)
+      timer      = Timer.new
+      rate       = Rate.new(:progress => progress,
+                            :timer    => timer)
 
       progress.start
       timer.start

--- a/spec/lib/ruby-progressbar/components/time_spec.rb
+++ b/spec/lib/ruby-progressbar/components/time_spec.rb
@@ -9,8 +9,9 @@ describe Time do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
       progress   = Progress.new(:projector => projector)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       expect(time.elapsed_with_label).to eql 'Time: --:--:--'
     end
@@ -19,10 +20,12 @@ describe Time do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
       progress   = Progress.new(:projector => projector)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       timer.start
+      projector.start
 
       expect(time.elapsed_with_label).to eql 'Time: 00:00:00'
     end
@@ -31,12 +34,14 @@ describe Time do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
       progress   = Progress.new(:projector => projector)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       Timecop.freeze(-16_093)
 
       timer.start
+      projector.start
 
       Timecop.return
 
@@ -47,12 +52,14 @@ describe Time do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
       progress   = Progress.new(:projector => projector)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       Timecop.freeze(-16_093)
 
       timer.start
+      projector.start
 
       Timecop.return
       Timecop.freeze(-32)
@@ -68,12 +75,14 @@ describe Time do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
       progress   = Progress.new(:projector => projector)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       Timecop.freeze(-16_093)
 
       timer.start
+      projector.start
 
       Timecop.return
 
@@ -89,13 +98,18 @@ describe Time do
       projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
       progress   = Progress.new(:projector => projector,
                                 :total     => 100)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       Timecop.freeze(-13_332)
 
       timer.start
-      50.times { progress.increment }
+      projector.start
+      50.times do
+        progress.increment
+        projector.increment
+      end
 
       Timecop.return
 
@@ -107,10 +121,12 @@ describe Time do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
       progress   = Progress.new(:projector => projector, :total => 100)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       timer.start
+      projector.start
 
       expect(time.estimated_with_unknown_oob).to eql ' ETA: ??:??:??'
     end
@@ -120,17 +136,47 @@ describe Time do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
       progress   = Progress.new(:projector => projector, :total => 100)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       Timecop.freeze(-13_332)
 
       timer.start
-      50.times { progress.increment }
+      projector.start
+      50.times do
+        progress.increment
+        projector.increment
+      end
 
       Timecop.return
 
       progress.reset
+
+      expect(time.estimated_with_unknown_oob).to eql ' ETA: ??:??:??'
+    end
+
+    it 'displays unknown time remaining when progress has been made and then rate ' \
+       'is reset' do
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector, :total => 100)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
+
+      Timecop.freeze(-13_332)
+
+      timer.start
+      projector.start
+      50.times do
+        progress.increment
+        projector.increment
+      end
+
+      Timecop.return
+
+      projector.reset
 
       expect(time.estimated_with_unknown_oob).to eql ' ETA: ??:??:??'
     end
@@ -143,12 +189,17 @@ describe Time do
                                 :total     => 100)
       time       = Time.new(:out_of_bounds_time_format => :unknown,
                             :timer                     => timer,
-                            :progress                  => progress)
+                            :progress                  => progress,
+                            :projector                 => projector)
 
       Timecop.freeze(-120_000)
 
       timer.start
-      25.times { progress.increment }
+      projector.start
+      25.times do
+        progress.increment
+        projector.increment
+      end
 
       Timecop.return
 
@@ -161,13 +212,18 @@ describe Time do
       projector  = Calculators::SmoothedAverage.new(:strength => 0.5)
       progress   = Progress.new(:projector => projector,
                                 :total     => 100)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       Timecop.freeze(-13_332)
 
       timer.start
-      50.times { progress.increment }
+      projector.start
+      50.times do
+        progress.increment
+        projector.increment
+      end
 
       Timecop.return
 
@@ -183,13 +239,18 @@ describe Time do
       projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
       progress   = Progress.new(:projector => projector,
                                 :total     => 100)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       Timecop.freeze(-13_332)
 
       timer.start
-      50.times { progress.increment }
+      projector.start
+      50.times do
+        progress.increment
+        projector.increment
+      end
 
       Timecop.return
 
@@ -204,12 +265,17 @@ describe Time do
                                 :total     => 100)
       time       = Time.new(:out_of_bounds_time_format => :friendly,
                             :timer                     => timer,
-                            :progress                  => progress)
+                            :progress                  => progress,
+                            :projector                 => projector)
 
       Timecop.freeze(-120_000)
 
       timer.start
-      25.times { progress.increment }
+      projector.start
+      25.times do
+        progress.increment
+        projector.increment
+      end
 
       Timecop.return
 
@@ -223,13 +289,18 @@ describe Time do
       projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
       progress   = Progress.new(:projector => projector,
                                 :total     => 100)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       Timecop.freeze(-13_332)
 
       timer.start
-      50.times { progress.increment }
+      projector.start
+      50.times do
+        progress.increment
+        projector.increment
+      end
 
       Timecop.return
 
@@ -244,12 +315,17 @@ describe Time do
                                 :total     => 100)
       time       = Time.new(:out_of_bounds_time_format => nil,
                             :timer                     => timer,
-                            :progress                  => progress)
+                            :progress                  => progress,
+                            :projector                 => projector)
 
       Timecop.freeze(-120_000)
 
       timer.start
-      25.times { progress.increment }
+      projector.start
+      25.times do
+        progress.increment
+        projector.increment
+      end
 
       Timecop.return
 
@@ -264,11 +340,14 @@ describe Time do
       projector  = Calculators::SmoothedAverage.new
       progress   = Progress.new(:projector => projector,
                                 :total     => 100)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       timer.start
+      projector.start
       progress.increment
+      projector.increment
 
       expect(time.estimated_with_label).to eql ' ETA: 00:00:00'
     end
@@ -278,13 +357,18 @@ describe Time do
       projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
       progress   = Progress.new(:projector => projector,
                                 :total     => 100)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       Timecop.freeze(-13_332)
 
       timer.start
-      50.times { progress.increment }
+      projector.start
+      50.times do
+        progress.increment
+        projector.increment
+      end
 
       Timecop.return
 
@@ -297,17 +381,25 @@ describe Time do
       projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
       progress   = Progress.new(:projector => projector,
                                 :total     => 100)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       Timecop.freeze(-13_332)
 
       timer.start
-      50.times { progress.increment }
+      projector.start
+      50.times do
+        progress.increment
+        projector.increment
+      end
 
       Timecop.return
 
-      20.times { progress.decrement }
+      20.times do
+        progress.decrement
+        projector.decrement
+      end
 
       expect(time.estimated_with_label).to eql ' ETA: 08:38:28'
     end
@@ -318,33 +410,46 @@ describe Time do
       projector  = Calculators::SmoothedAverage.new(:strength => 0.5)
       progress   = Progress.new(:projector => projector,
                                 :total     => 100)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      time       = Time.new(:timer     => timer,
+                            :progress  => progress,
+                            :projector => projector)
 
       Timecop.freeze(-13_332)
 
       timer.start
-      50.times { progress.increment }
+      projector.start
+      50.times do
+        progress.increment
+        projector.increment
+      end
 
       Timecop.return
 
-      20.times { progress.decrement }
+      20.times do
+        progress.decrement
+        projector.decrement
+      end
 
       expect(time.estimated_with_label).to eql ' ETA: 08:14:34'
     end
 
     it 'displays smoothed estimated time after progress has been made' do
-      timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new(:strength => 0.5)
-      progress   = Progress.new(:projector => projector,
-                                :total     => 100)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      timer     = Timer.new
+      projector = Calculators::SmoothedAverage.new(:strength => 0.5)
+      progress  = Progress.new(:projector => projector,
+                               :total     => 100)
+      time      = Time.new(:timer     => timer,
+                           :progress  => progress,
+                           :projector => projector)
 
       Timecop.freeze(-13_332)
 
       timer.start
-      50.times { progress.increment }
+      projector.start
+      50.times do
+        progress.increment
+        projector.increment
+      end
 
       Timecop.return
 
@@ -353,12 +458,13 @@ describe Time do
 
     it 'displays the estimated time remaining properly even for progress increments ' \
        'very short intervals' do
-      timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new(:strength => 0.1)
-      progress   = Progress.new(:projector => projector,
-                                :total     => 10)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      timer     = Timer.new
+      projector = Calculators::SmoothedAverage.new(:strength => 0.1)
+      progress  = Progress.new(:projector => projector,
+                               :total     => 10)
+      time      = Time.new(:timer     => timer,
+                           :progress  => progress,
+                           :projector => projector)
 
       estimated_time_results = []
       now                    = ::Time.now
@@ -366,10 +472,12 @@ describe Time do
       Timecop.freeze(now)
 
       timer.start
+      projector.start
 
       10.times do
         Timecop.freeze(now += 0.5)
         progress.increment
+        projector.increment
 
         estimated_time_results << time.estimated_with_label
       end
@@ -396,15 +504,17 @@ describe Time do
 
   describe '#estimated_wall_clock' do
     it 'displays the wall clock time as unknown when the timer has been reset' do
-      timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new
-      progress   = Progress.new(:projector => projector)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      timer     = Timer.new
+      projector = Calculators::SmoothedAverage.new
+      progress  = Progress.new(:projector => projector)
+      time      = Time.new(:timer     => timer,
+                           :progress  => progress,
+                           :projector => projector)
 
       Timecop.freeze(-16_093)
 
       timer.start
+      projector.start
 
       Timecop.return
 
@@ -414,15 +524,17 @@ describe Time do
     end
 
     it 'displays the wall clock time as unknown when the progress has not begun' do
-      timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new
-      progress   = Progress.new(:projector => projector)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      timer     = Timer.new
+      projector = Calculators::SmoothedAverage.new
+      progress  = Progress.new(:projector => projector)
+      time      = Time.new(:timer     => timer,
+                           :progress  => progress,
+                           :projector => projector)
 
       Timecop.freeze(-16_093)
 
       timer.start
+      projector.start
 
       Timecop.return
 
@@ -430,15 +542,17 @@ describe Time do
     end
 
     it 'displays the completed wall clock time if the progress is finished' do
-      timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new
-      progress   = Progress.new(:projector => projector)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      timer     = Timer.new
+      projector = Calculators::SmoothedAverage.new
+      progress  = Progress.new(:projector => projector)
+      time      = Time.new(:timer     => timer,
+                           :progress  => progress,
+                           :projector => projector)
 
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0))
 
       timer.start
+      projector.start
 
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 30, 0))
 
@@ -451,16 +565,19 @@ describe Time do
     end
 
     it 'displays the estimated wall clock time if the progress is ongoing' do
-      timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
-      progress   = Progress.new(:projector => projector)
-      time       = Time.new(:timer    => timer,
-                            :progress => progress)
+      timer     = Timer.new
+      projector = Calculators::SmoothedAverage.new(:strength => 0.0)
+      progress  = Progress.new(:projector => projector)
+      time      = Time.new(:timer     => timer,
+                           :progress  => progress,
+                           :projector => projector)
 
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0))
 
       timer.start
-      progress.progress = 50
+      projector.start
+      progress.progress  = 50
+      projector.progress = 50
 
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 15, 0))
 

--- a/spec/lib/ruby-progressbar/components/time_spec.rb
+++ b/spec/lib/ruby-progressbar/components/time_spec.rb
@@ -7,7 +7,7 @@ describe Time do
   describe '#elapsed_with_label' do
     it 'displays unknown elapsed time when the timer has not been started' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -18,7 +18,7 @@ describe Time do
 
     it 'displays elapsed time when the timer has just been started' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -32,7 +32,7 @@ describe Time do
 
     it 'displays elapsed time if it was previously started' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -50,7 +50,7 @@ describe Time do
 
     it 'displays elapsed time frozen to a specific time if it was previously stopped' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -73,7 +73,7 @@ describe Time do
 
     it 'displays unknown elapsed time after reset has been called' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -95,7 +95,7 @@ describe Time do
   describe '#estimated_with_unknown_oob' do
     it 'displays estimated time if it is known' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      projector  = Projectors::SmoothedAverage.new(:strength => 0.0)
       progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -118,7 +118,7 @@ describe Time do
     it 'displays an unknown estimated time remaining when the timer has been started ' \
        'but no progress has been made' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -133,7 +133,7 @@ describe Time do
     it 'displays unknown time remaining when progress has been made and then progress ' \
        'is reset' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -158,7 +158,7 @@ describe Time do
     it 'displays unknown time remaining when progress has been made and then rate ' \
        'is reset' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -183,7 +183,7 @@ describe Time do
     it 'displays estimated time of "??:??:??" when estimated time is out of bounds ' \
        'and the out of bounds format is set to "unknown"' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      projector  = Projectors::SmoothedAverage.new(:strength => 0.0)
       progress   = Progress.new(:total => 100)
       time       = Time.new(:out_of_bounds_time_format => :unknown,
                             :timer                     => timer,
@@ -207,7 +207,7 @@ describe Time do
     it 'displays smoothed unknown estimated time when reset is called after progress ' \
        'is made' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new(:strength => 0.5)
+      projector  = Projectors::SmoothedAverage.new(:strength => 0.5)
       progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -233,7 +233,7 @@ describe Time do
   describe '#estimated_with_friendly_oob' do
     it 'displays estimated time if it is known' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      projector  = Projectors::SmoothedAverage.new(:strength => 0.0)
       progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -256,7 +256,7 @@ describe Time do
     it 'displays estimated time of "> 4 Days" when estimated time is out of bounds ' \
        'and the out of bounds format is set to "friendly"' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      projector  = Projectors::SmoothedAverage.new(:strength => 0.0)
       progress   = Progress.new(:total => 100)
       time       = Time.new(:out_of_bounds_time_format => :friendly,
                             :timer                     => timer,
@@ -281,7 +281,7 @@ describe Time do
   describe '#estimated_with_no_oob' do
     it 'displays estimated time if it is known' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      projector  = Projectors::SmoothedAverage.new(:strength => 0.0)
       progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -304,7 +304,7 @@ describe Time do
     it 'displays actual estimated time when estimated time is out of bounds and the ' \
        'out of bounds format is unset' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      projector  = Projectors::SmoothedAverage.new(:strength => 0.0)
       progress   = Progress.new(:total => 100)
       time       = Time.new(:out_of_bounds_time_format => nil,
                             :timer                     => timer,
@@ -330,7 +330,7 @@ describe Time do
     it 'does not display unknown time remaining when the timer has been started and ' \
        'it is incremented' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new
+      projector  = Projectors::SmoothedAverage.new
       progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -346,7 +346,7 @@ describe Time do
 
     it 'displays unsmoothed time remaining when progress has been made' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      projector  = Projectors::SmoothedAverage.new(:strength => 0.0)
       progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -369,7 +369,7 @@ describe Time do
     it 'displays unsmoothed time remaining when progress has been made even after the ' \
        'bar is decremented' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      projector  = Projectors::SmoothedAverage.new(:strength => 0.0)
       progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -397,7 +397,7 @@ describe Time do
     it 'displays smoothed estimated time properly even when taking decrements into ' \
        'account' do
       timer      = Timer.new
-      projector  = Calculators::SmoothedAverage.new(:strength => 0.5)
+      projector  = Projectors::SmoothedAverage.new(:strength => 0.5)
       progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
@@ -424,7 +424,7 @@ describe Time do
 
     it 'displays smoothed estimated time after progress has been made' do
       timer     = Timer.new
-      projector = Calculators::SmoothedAverage.new(:strength => 0.5)
+      projector = Projectors::SmoothedAverage.new(:strength => 0.5)
       progress  = Progress.new(:total => 100)
       time      = Time.new(:timer     => timer,
                            :progress  => progress,
@@ -447,7 +447,7 @@ describe Time do
     it 'displays the estimated time remaining properly even for progress increments ' \
        'very short intervals' do
       timer     = Timer.new
-      projector = Calculators::SmoothedAverage.new(:strength => 0.1)
+      projector = Projectors::SmoothedAverage.new(:strength => 0.1)
       progress  = Progress.new(:total => 10)
       time      = Time.new(:timer     => timer,
                            :progress  => progress,
@@ -492,7 +492,7 @@ describe Time do
   describe '#estimated_wall_clock' do
     it 'displays the wall clock time as unknown when the timer has been reset' do
       timer     = Timer.new
-      projector = Calculators::SmoothedAverage.new
+      projector = Projectors::SmoothedAverage.new
       progress  = Progress.new
       time      = Time.new(:timer     => timer,
                            :progress  => progress,
@@ -512,7 +512,7 @@ describe Time do
 
     it 'displays the wall clock time as unknown when the progress has not begun' do
       timer     = Timer.new
-      projector = Calculators::SmoothedAverage.new
+      projector = Projectors::SmoothedAverage.new
       progress  = Progress.new
       time      = Time.new(:timer     => timer,
                            :progress  => progress,
@@ -530,7 +530,7 @@ describe Time do
 
     it 'displays the completed wall clock time if the progress is finished' do
       timer     = Timer.new
-      projector = Calculators::SmoothedAverage.new
+      projector = Projectors::SmoothedAverage.new
       progress  = Progress.new
       time      = Time.new(:timer     => timer,
                            :progress  => progress,
@@ -553,7 +553,7 @@ describe Time do
 
     it 'displays the estimated wall clock time if the progress is ongoing' do
       timer     = Timer.new
-      projector = Calculators::SmoothedAverage.new(:strength => 0.0)
+      projector = Projectors::SmoothedAverage.new(:strength => 0.0)
       progress  = Progress.new
       time      = Time.new(:timer     => timer,
                            :progress  => progress,

--- a/spec/lib/ruby-progressbar/components/time_spec.rb
+++ b/spec/lib/ruby-progressbar/components/time_spec.rb
@@ -6,19 +6,21 @@ module   Components
 describe Time do
   describe '#elapsed_with_label' do
     it 'displays unknown elapsed time when the timer has not been started' do
-      timer    = Timer.new
-      progress = Progress.new
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       expect(time.elapsed_with_label).to eql 'Time: --:--:--'
     end
 
     it 'displays elapsed time when the timer has just been started' do
-      timer    = Timer.new
-      progress = Progress.new
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       timer.start
 
@@ -26,10 +28,11 @@ describe Time do
     end
 
     it 'displays elapsed time if it was previously started' do
-      timer    = Timer.new
-      progress = Progress.new
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-16_093)
 
@@ -41,10 +44,11 @@ describe Time do
     end
 
     it 'displays elapsed time frozen to a specific time if it was previously stopped' do
-      timer    = Timer.new
-      progress = Progress.new
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-16_093)
 
@@ -61,10 +65,11 @@ describe Time do
     end
 
     it 'displays unknown elapsed time after reset has been called' do
-      timer    = Timer.new
-      progress = Progress.new
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-16_093)
 
@@ -80,11 +85,12 @@ describe Time do
 
   describe '#estimated_with_unknown_oob' do
     it 'displays estimated time if it is known' do
-      timer    = Timer.new
-      progress = Progress.new(:total                => 100,
-                              :running_average_rate => 0.0)
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      progress   = Progress.new(:projector => projector,
+                                :total     => 100)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-13_332)
 
@@ -98,10 +104,11 @@ describe Time do
 
     it 'displays an unknown estimated time remaining when the timer has been started ' \
        'but no progress has been made' do
-      timer    = Timer.new
-      progress = Progress.new(:total => 100)
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector, :total => 100)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       timer.start
 
@@ -110,10 +117,11 @@ describe Time do
 
     it 'displays unknown time remaining when progress has been made and then progress ' \
        'is reset' do
-      timer    = Timer.new
-      progress = Progress.new(:total => 100)
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector, :total => 100)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-13_332)
 
@@ -129,11 +137,13 @@ describe Time do
 
     it 'displays estimated time of "??:??:??" when estimated time is out of bounds ' \
        'and the out of bounds format is set to "unknown"' do
-      timer    = Timer.new
-      progress = Progress.new(:total => 100, :running_average_rate => 0.0)
-      time     = Time.new(:out_of_bounds_time_format => :unknown,
-                          :timer                     => timer,
-                          :progress                  => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      progress   = Progress.new(:projector => projector,
+                                :total     => 100)
+      time       = Time.new(:out_of_bounds_time_format => :unknown,
+                            :timer                     => timer,
+                            :progress                  => progress)
 
       Timecop.freeze(-120_000)
 
@@ -147,10 +157,12 @@ describe Time do
 
     it 'displays smoothed unknown estimated time when reset is called after progress ' \
        'is made' do
-      timer    = Timer.new
-      progress = Progress.new(:total => 100, :running_average_rate => 0.5)
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new(:strength => 0.5)
+      progress   = Progress.new(:projector => projector,
+                                :total     => 100)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-13_332)
 
@@ -167,11 +179,12 @@ describe Time do
 
   describe '#estimated_with_friendly_oob' do
     it 'displays estimated time if it is known' do
-      timer    = Timer.new
-      progress = Progress.new(:total                => 100,
-                              :running_average_rate => 0.0)
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      progress   = Progress.new(:projector => projector,
+                                :total     => 100)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-13_332)
 
@@ -185,11 +198,13 @@ describe Time do
 
     it 'displays estimated time of "> 4 Days" when estimated time is out of bounds ' \
        'and the out of bounds format is set to "friendly"' do
-      timer    = Timer.new
-      progress = Progress.new(:total => 100, :running_average_rate => 0.0)
-      time     = Time.new(:out_of_bounds_time_format => :friendly,
-                          :timer                     => timer,
-                          :progress                  => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      progress   = Progress.new(:projector => projector,
+                                :total     => 100)
+      time       = Time.new(:out_of_bounds_time_format => :friendly,
+                            :timer                     => timer,
+                            :progress                  => progress)
 
       Timecop.freeze(-120_000)
 
@@ -204,11 +219,12 @@ describe Time do
 
   describe '#estimated_with_no_oob' do
     it 'displays estimated time if it is known' do
-      timer    = Timer.new
-      progress = Progress.new(:total                => 100,
-                              :running_average_rate => 0.0)
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      progress   = Progress.new(:projector => projector,
+                                :total     => 100)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-13_332)
 
@@ -222,11 +238,13 @@ describe Time do
 
     it 'displays actual estimated time when estimated time is out of bounds and the ' \
        'out of bounds format is unset' do
-      timer    = Timer.new
-      progress = Progress.new(:total => 100, :running_average_rate => 0.0)
-      time     = Time.new(:out_of_bounds_time_format => nil,
-                          :timer                     => timer,
-                          :progress                  => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      progress   = Progress.new(:projector => projector,
+                                :total     => 100)
+      time       = Time.new(:out_of_bounds_time_format => nil,
+                            :timer                     => timer,
+                            :progress                  => progress)
 
       Timecop.freeze(-120_000)
 
@@ -242,10 +260,12 @@ describe Time do
   describe '#estimated_with_label' do
     it 'does not display unknown time remaining when the timer has been started and ' \
        'it is incremented' do
-      timer    = Timer.new
-      progress = Progress.new(:total => 100)
-      time = Time.new(:timer    => timer,
-                      :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector,
+                                :total     => 100)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       timer.start
       progress.increment
@@ -254,10 +274,12 @@ describe Time do
     end
 
     it 'displays unsmoothed time remaining when progress has been made' do
-      timer    = Timer.new
-      progress = Progress.new(:total => 100, :running_average_rate => 0.0)
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      progress   = Progress.new(:projector => projector,
+                                :total     => 100)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-13_332)
 
@@ -271,10 +293,12 @@ describe Time do
 
     it 'displays unsmoothed time remaining when progress has been made even after the ' \
        'bar is decremented' do
-      timer    = Timer.new
-      progress = Progress.new(:total => 100, :running_average_rate => 0.0)
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      progress   = Progress.new(:projector => projector,
+                                :total     => 100)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-13_332)
 
@@ -290,10 +314,12 @@ describe Time do
 
     it 'displays smoothed estimated time properly even when taking decrements into ' \
        'account' do
-      timer    = Timer.new
-      progress = Progress.new(:total => 100, :running_average_rate => 0.5)
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new(:strength => 0.5)
+      progress   = Progress.new(:projector => projector,
+                                :total     => 100)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-13_332)
 
@@ -308,10 +334,12 @@ describe Time do
     end
 
     it 'displays smoothed estimated time after progress has been made' do
-      timer    = Timer.new
-      progress = Progress.new(:total => 100, :running_average_rate => 0.5)
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new(:strength => 0.5)
+      progress   = Progress.new(:projector => projector,
+                                :total     => 100)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-13_332)
 
@@ -325,10 +353,12 @@ describe Time do
 
     it 'displays the estimated time remaining properly even for progress increments ' \
        'very short intervals' do
-      timer    = Timer.new
-      progress = Progress.new(:total => 10, :running_average_rate => 0.1)
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new(:strength => 0.1)
+      progress   = Progress.new(:projector => projector,
+                                :total     => 10)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       estimated_time_results = []
       now                    = ::Time.now
@@ -366,10 +396,11 @@ describe Time do
 
   describe '#estimated_wall_clock' do
     it 'displays the wall clock time as unknown when the timer has been reset' do
-      timer    = Timer.new
-      progress = Progress.new
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-16_093)
 
@@ -383,10 +414,11 @@ describe Time do
     end
 
     it 'displays the wall clock time as unknown when the progress has not begun' do
-      timer    = Timer.new
-      progress = Progress.new
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(-16_093)
 
@@ -398,10 +430,11 @@ describe Time do
     end
 
     it 'displays the completed wall clock time if the progress is finished' do
-      timer    = Timer.new
-      progress = Progress.new
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new
+      progress   = Progress.new(:projector => projector)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0))
 
@@ -418,10 +451,11 @@ describe Time do
     end
 
     it 'displays the estimated wall clock time if the progress is ongoing' do
-      timer    = Timer.new
-      progress = Progress.new(:running_average_rate => 0.0)
-      time     = Time.new(:timer    => timer,
-                          :progress => progress)
+      timer      = Timer.new
+      projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
+      progress   = Progress.new(:projector => projector)
+      time       = Time.new(:timer    => timer,
+                            :progress => progress)
 
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0))
 

--- a/spec/lib/ruby-progressbar/components/time_spec.rb
+++ b/spec/lib/ruby-progressbar/components/time_spec.rb
@@ -8,7 +8,7 @@ describe Time do
     it 'displays unknown elapsed time when the timer has not been started' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
-      progress   = Progress.new(:projector => projector)
+      progress   = Progress.new
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -19,7 +19,7 @@ describe Time do
     it 'displays elapsed time when the timer has just been started' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
-      progress   = Progress.new(:projector => projector)
+      progress   = Progress.new
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -33,7 +33,7 @@ describe Time do
     it 'displays elapsed time if it was previously started' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
-      progress   = Progress.new(:projector => projector)
+      progress   = Progress.new
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -51,7 +51,7 @@ describe Time do
     it 'displays elapsed time frozen to a specific time if it was previously stopped' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
-      progress   = Progress.new(:projector => projector)
+      progress   = Progress.new
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -74,7 +74,7 @@ describe Time do
     it 'displays unknown elapsed time after reset has been called' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
-      progress   = Progress.new(:projector => projector)
+      progress   = Progress.new
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -96,8 +96,7 @@ describe Time do
     it 'displays estimated time if it is known' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
-      progress   = Progress.new(:projector => projector,
-                                :total     => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -120,7 +119,7 @@ describe Time do
        'but no progress has been made' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
-      progress   = Progress.new(:projector => projector, :total => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -135,7 +134,7 @@ describe Time do
        'is reset' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
-      progress   = Progress.new(:projector => projector, :total => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -160,7 +159,7 @@ describe Time do
        'is reset' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
-      progress   = Progress.new(:projector => projector, :total => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -185,8 +184,7 @@ describe Time do
        'and the out of bounds format is set to "unknown"' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
-      progress   = Progress.new(:projector => projector,
-                                :total     => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:out_of_bounds_time_format => :unknown,
                             :timer                     => timer,
                             :progress                  => progress,
@@ -210,8 +208,7 @@ describe Time do
        'is made' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new(:strength => 0.5)
-      progress   = Progress.new(:projector => projector,
-                                :total     => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -237,8 +234,7 @@ describe Time do
     it 'displays estimated time if it is known' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
-      progress   = Progress.new(:projector => projector,
-                                :total     => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -261,8 +257,7 @@ describe Time do
        'and the out of bounds format is set to "friendly"' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
-      progress   = Progress.new(:projector => projector,
-                                :total     => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:out_of_bounds_time_format => :friendly,
                             :timer                     => timer,
                             :progress                  => progress,
@@ -287,8 +282,7 @@ describe Time do
     it 'displays estimated time if it is known' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
-      progress   = Progress.new(:projector => projector,
-                                :total     => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -311,8 +305,7 @@ describe Time do
        'out of bounds format is unset' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
-      progress   = Progress.new(:projector => projector,
-                                :total     => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:out_of_bounds_time_format => nil,
                             :timer                     => timer,
                             :progress                  => progress,
@@ -338,8 +331,7 @@ describe Time do
        'it is incremented' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new
-      progress   = Progress.new(:projector => projector,
-                                :total     => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -355,8 +347,7 @@ describe Time do
     it 'displays unsmoothed time remaining when progress has been made' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
-      progress   = Progress.new(:projector => projector,
-                                :total     => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -379,8 +370,7 @@ describe Time do
        'bar is decremented' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new(:strength => 0.0)
-      progress   = Progress.new(:projector => projector,
-                                :total     => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -408,8 +398,7 @@ describe Time do
        'account' do
       timer      = Timer.new
       projector  = Calculators::SmoothedAverage.new(:strength => 0.5)
-      progress   = Progress.new(:projector => projector,
-                                :total     => 100)
+      progress   = Progress.new(:total => 100)
       time       = Time.new(:timer     => timer,
                             :progress  => progress,
                             :projector => projector)
@@ -436,8 +425,7 @@ describe Time do
     it 'displays smoothed estimated time after progress has been made' do
       timer     = Timer.new
       projector = Calculators::SmoothedAverage.new(:strength => 0.5)
-      progress  = Progress.new(:projector => projector,
-                               :total     => 100)
+      progress  = Progress.new(:total => 100)
       time      = Time.new(:timer     => timer,
                            :progress  => progress,
                            :projector => projector)
@@ -460,8 +448,7 @@ describe Time do
        'very short intervals' do
       timer     = Timer.new
       projector = Calculators::SmoothedAverage.new(:strength => 0.1)
-      progress  = Progress.new(:projector => projector,
-                               :total     => 10)
+      progress  = Progress.new(:total => 10)
       time      = Time.new(:timer     => timer,
                            :progress  => progress,
                            :projector => projector)
@@ -506,7 +493,7 @@ describe Time do
     it 'displays the wall clock time as unknown when the timer has been reset' do
       timer     = Timer.new
       projector = Calculators::SmoothedAverage.new
-      progress  = Progress.new(:projector => projector)
+      progress  = Progress.new
       time      = Time.new(:timer     => timer,
                            :progress  => progress,
                            :projector => projector)
@@ -526,7 +513,7 @@ describe Time do
     it 'displays the wall clock time as unknown when the progress has not begun' do
       timer     = Timer.new
       projector = Calculators::SmoothedAverage.new
-      progress  = Progress.new(:projector => projector)
+      progress  = Progress.new
       time      = Time.new(:timer     => timer,
                            :progress  => progress,
                            :projector => projector)
@@ -544,7 +531,7 @@ describe Time do
     it 'displays the completed wall clock time if the progress is finished' do
       timer     = Timer.new
       projector = Calculators::SmoothedAverage.new
-      progress  = Progress.new(:projector => projector)
+      progress  = Progress.new
       time      = Time.new(:timer     => timer,
                            :progress  => progress,
                            :projector => projector)
@@ -567,7 +554,7 @@ describe Time do
     it 'displays the estimated wall clock time if the progress is ongoing' do
       timer     = Timer.new
       projector = Calculators::SmoothedAverage.new(:strength => 0.0)
-      progress  = Progress.new(:projector => projector)
+      progress  = Progress.new
       time      = Time.new(:timer     => timer,
                            :progress  => progress,
                            :projector => projector)

--- a/spec/lib/ruby-progressbar/format/formatter_spec.rb
+++ b/spec/lib/ruby-progressbar/format/formatter_spec.rb
@@ -138,7 +138,7 @@ describe Formatter do
     end
 
     it 'is the estimated time remaining when called after the bar is started' do
-      progressbar = ProgressBar::Base.new(:smoothing => 0.0)
+      progressbar = ProgressBar::Base.new(:projector => { :strength => 0.0 })
 
       Timecop.freeze(to_the_past) do
         progressbar.start
@@ -150,7 +150,7 @@ describe Formatter do
 
     it 'is "??:??:??" when it could take 100 hours or longer to finish' do
       progressbar = ProgressBar::Base.new(:total     => 100,
-                                          :smoothing => 0.0)
+                                          :projector => { :strength => 0.0 })
 
       Timecop.freeze(one_hundred_hours_ago) do
         progressbar.start
@@ -207,7 +207,7 @@ describe Formatter do
       progressbar = nil
 
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0)) do
-        progressbar = ProgressBar::Base.new(:smoothing => 0.0)
+        progressbar = ProgressBar::Base.new(:projector => { :strength => 0.0 })
 
         progressbar.start
         progressbar.progress = 50
@@ -262,7 +262,7 @@ describe Formatter do
     end
 
     it 'is the estimated time remaining when called after the bar is started' do
-      progressbar = ProgressBar::Base.new(:smoothing => 0.0)
+      progressbar = ProgressBar::Base.new(:projector => { :strength => 0.0 })
 
       Timecop.freeze(to_the_past) do
         progressbar.start
@@ -288,7 +288,7 @@ describe Formatter do
 
     it 'is "> 4 Days" when it could take 100 hours or longer to finish' do
       progressbar = ProgressBar::Base.new(:total     => 100,
-                                          :smoothing => 0.0)
+                                          :projector => { :strength => 0.0 })
 
       Timecop.freeze(one_hundred_hours_ago) do
         progressbar.start
@@ -328,7 +328,7 @@ describe Formatter do
     end
 
     it 'is the estimated time remaining when called after the bar is started' do
-      progressbar = ProgressBar::Base.new(:smoothing => 0.0)
+      progressbar = ProgressBar::Base.new(:projector => { :strength => 0.0 })
 
       Timecop.freeze(to_the_past) do
         progressbar.start
@@ -340,7 +340,7 @@ describe Formatter do
 
     it 'is the exact estimated time when it could take 100 hours or longer to finish' do
       progressbar = ProgressBar::Base.new(:total     => 100,
-                                          :smoothing => 0.0)
+                                          :projector => { :strength => 0.0 })
 
       Timecop.freeze(one_hundred_hours_ago) do
         progressbar.start

--- a/spec/lib/ruby-progressbar/format/formatter_spec.rb
+++ b/spec/lib/ruby-progressbar/format/formatter_spec.rb
@@ -138,7 +138,7 @@ describe Formatter do
     end
 
     it 'is the estimated time remaining when called after the bar is started' do
-      progressbar = ProgressBar::Base.new(:running_average_rate => 0.0)
+      progressbar = ProgressBar::Base.new(:smoothing => 0.0)
 
       Timecop.freeze(to_the_past) do
         progressbar.start
@@ -149,7 +149,8 @@ describe Formatter do
     end
 
     it 'is "??:??:??" when it could take 100 hours or longer to finish' do
-      progressbar = ProgressBar::Base.new(:total => 100, :running_average_rate => 0.0)
+      progressbar = ProgressBar::Base.new(:total     => 100,
+                                          :smoothing => 0.0)
 
       Timecop.freeze(one_hundred_hours_ago) do
         progressbar.start
@@ -206,7 +207,7 @@ describe Formatter do
       progressbar = nil
 
       Timecop.freeze(::Time.utc(2020, 1, 1, 0, 0, 0)) do
-        progressbar = ProgressBar::Base.new(:running_average_rate => 0.0)
+        progressbar = ProgressBar::Base.new(:smoothing => 0.0)
 
         progressbar.start
         progressbar.progress = 50
@@ -261,7 +262,7 @@ describe Formatter do
     end
 
     it 'is the estimated time remaining when called after the bar is started' do
-      progressbar = ProgressBar::Base.new(:running_average_rate => 0.0)
+      progressbar = ProgressBar::Base.new(:smoothing => 0.0)
 
       Timecop.freeze(to_the_past) do
         progressbar.start
@@ -286,7 +287,8 @@ describe Formatter do
     end
 
     it 'is "> 4 Days" when it could take 100 hours or longer to finish' do
-      progressbar = ProgressBar::Base.new(:total => 100, :running_average_rate => 0.0)
+      progressbar = ProgressBar::Base.new(:total     => 100,
+                                          :smoothing => 0.0)
 
       Timecop.freeze(one_hundred_hours_ago) do
         progressbar.start
@@ -326,7 +328,7 @@ describe Formatter do
     end
 
     it 'is the estimated time remaining when called after the bar is started' do
-      progressbar = ProgressBar::Base.new(:running_average_rate => 0.0)
+      progressbar = ProgressBar::Base.new(:smoothing => 0.0)
 
       Timecop.freeze(to_the_past) do
         progressbar.start
@@ -337,7 +339,8 @@ describe Formatter do
     end
 
     it 'is the exact estimated time when it could take 100 hours or longer to finish' do
-      progressbar = ProgressBar::Base.new(:total => 100, :running_average_rate => 0.0)
+      progressbar = ProgressBar::Base.new(:total     => 100,
+                                          :smoothing => 0.0)
 
       Timecop.freeze(one_hundred_hours_ago) do
         progressbar.start

--- a/spec/lib/ruby-progressbar/progress_spec.rb
+++ b/spec/lib/ruby-progressbar/progress_spec.rb
@@ -4,8 +4,7 @@ require 'ruby-progressbar/progress'
 class    ProgressBar
 describe Progress do
   it 'knows the default total when no parameters are passed' do
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:projector => projector)
+    progress = Progress.new
 
     expect(progress.total).to eql Progress::DEFAULT_TOTAL
   end
@@ -13,8 +12,7 @@ describe Progress do
   it 'knows the default beginning progress when no parameters are passed and ' \
      'the progress has not been started' do
 
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:projector => projector)
+    progress = Progress.new
 
     expect(progress.progress).to be_zero
   end
@@ -22,8 +20,7 @@ describe Progress do
   it 'knows the default starting value when no parameters are passed and the ' \
      'progress has been started' do
 
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:projector => projector)
+    progress = Progress.new
 
     progress.start
 
@@ -33,8 +30,7 @@ describe Progress do
   it 'knows the given starting value when no parameters are passed and the ' \
      'progress is started with a starting value' do
 
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:projector => projector)
+    progress = Progress.new
 
     progress.start :at => 10
 
@@ -42,25 +38,21 @@ describe Progress do
   end
 
   it 'knows how to finish itself even if the total is unknown' do
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:total => nil, :projector => projector)
+    progress = Progress.new :total => nil
 
     expect(progress.finish).to be(nil)
   end
 
   it 'knows the overridden total when the total is passed in' do
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:projector      => projector,
-                              :total          => 12,
-                              :progress_mark  => 'x',
-                              :remainder_mark => '.')
+    progress = Progress.new(:total          => 12,
+                            :progress_mark  => 'x',
+                            :remainder_mark => '.')
 
     expect(progress.total).to be 12
   end
 
   it 'knows the percentage completed when begun with no progress' do
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:projector => projector)
+    progress = Progress.new
 
     progress.start
 
@@ -68,8 +60,7 @@ describe Progress do
   end
 
   it 'knows the progress after it has been incremented' do
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:projector => projector)
+    progress = Progress.new
 
     progress.start
     progress.increment
@@ -78,8 +69,7 @@ describe Progress do
   end
 
   it 'knows the percentage completed after it has been incremented' do
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:total => 50, :projector => projector)
+    progress = Progress.new(:total => 50)
 
     progress.start
     progress.increment
@@ -88,8 +78,7 @@ describe Progress do
   end
 
   it 'knows to always round down the percentage completed' do
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:total => 200, :projector => projector)
+    progress = Progress.new(:total => 200)
 
     progress.start :at => 1
 
@@ -97,8 +86,7 @@ describe Progress do
   end
 
   it 'cannot increment past the total' do
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:total => 50, :projector => projector)
+    progress = Progress.new(:total => 50)
 
     progress.start :at => 50
     progress.increment
@@ -108,8 +96,7 @@ describe Progress do
   end
 
   it 'allow progress to be decremented once it is finished' do
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:total => 50, :projector => projector)
+    progress = Progress.new(:total => 50)
 
     progress.start :at => 50
     progress.decrement
@@ -118,49 +105,14 @@ describe Progress do
     expect(progress.percentage_completed).to be 98
   end
 
-  # rubocop:disable RSpec/BeEql
-  it 'knows the running average even when progress has been made' do
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:total => 50, :projector => projector)
-
-    projector.__send__(:projection=, 10)
-    projector.start
-    progress.start :at => 0
-
-    expect(progress.running_average).to be_zero
-
-    projector.progress += 40
-    progress.progress += 40
-
-    expect(progress.running_average).to eql 36.0
-  end
-
-  it 'knows the running average is reset even after progress is started' do
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:total => 50, :projector => projector)
-
-    projector.__send__(:projection=, 10)
-    projector.start
-    progress.start :at => 0
-
-    expect(progress.running_average).to be_zero
-
-    progress.start :at => 40
-
-    expect(progress.running_average).to eql 0.0
-  end
-  # rubocop:enable RSpec/BeEql
-
   it 'knows the percentage completed is 100% if the total is zero' do
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:total => 0, :projector => projector)
+    progress = Progress.new(:total => 0)
 
     expect(progress.percentage_completed).to be 100
   end
 
   it 'raises an error when passed a number larger than the total' do
-    projector  = Calculators::SmoothedAverage.new
-    progress   = Progress.new(:total => 100, :projector => projector)
+    progress = Progress.new(:total => 100)
 
     expect { progress.progress = 101 }.
       to \

--- a/spec/lib/ruby-progressbar/progress_spec.rb
+++ b/spec/lib/ruby-progressbar/progress_spec.rb
@@ -124,6 +124,7 @@ describe Progress do
     progress   = Progress.new(:total => 50, :projector => projector)
 
     projector.__send__(:projection=, 10)
+    projector.start
     progress.start :at => 0
 
     expect(progress.running_average).to be_zero
@@ -138,6 +139,7 @@ describe Progress do
     progress   = Progress.new(:total => 50, :projector => projector)
 
     projector.__send__(:projection=, 10)
+    projector.start
     progress.start :at => 0
 
     expect(progress.running_average).to be_zero

--- a/spec/lib/ruby-progressbar/progress_spec.rb
+++ b/spec/lib/ruby-progressbar/progress_spec.rb
@@ -4,7 +4,8 @@ require 'ruby-progressbar/progress'
 class    ProgressBar
 describe Progress do
   it 'knows the default total when no parameters are passed' do
-    progress = Progress.new
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:projector => projector)
 
     expect(progress.total).to eql Progress::DEFAULT_TOTAL
   end
@@ -12,7 +13,8 @@ describe Progress do
   it 'knows the default beginning progress when no parameters are passed and ' \
      'the progress has not been started' do
 
-    progress = Progress.new
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:projector => projector)
 
     expect(progress.progress).to be_zero
   end
@@ -20,7 +22,8 @@ describe Progress do
   it 'knows the default starting value when no parameters are passed and the ' \
      'progress has been started' do
 
-    progress = Progress.new
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:projector => projector)
 
     progress.start
 
@@ -30,7 +33,8 @@ describe Progress do
   it 'knows the given starting value when no parameters are passed and the ' \
      'progress is started with a starting value' do
 
-    progress = Progress.new
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:projector => projector)
 
     progress.start :at => 10
 
@@ -38,21 +42,25 @@ describe Progress do
   end
 
   it 'knows how to finish itself even if the total is unknown' do
-    progress = Progress.new :total => nil
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:total => nil, :projector => projector)
 
     expect(progress.finish).to be(nil)
   end
 
   it 'knows the overridden total when the total is passed in' do
-    progress = Progress.new(:total          => 12,
-                            :progress_mark  => 'x',
-                            :remainder_mark => '.')
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:projector      => projector,
+                              :total          => 12,
+                              :progress_mark  => 'x',
+                              :remainder_mark => '.')
 
     expect(progress.total).to be 12
   end
 
   it 'knows the percentage completed when begun with no progress' do
-    progress = Progress.new
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:projector => projector)
 
     progress.start
 
@@ -60,7 +68,8 @@ describe Progress do
   end
 
   it 'knows the progress after it has been incremented' do
-    progress = Progress.new
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:projector => projector)
 
     progress.start
     progress.increment
@@ -69,7 +78,8 @@ describe Progress do
   end
 
   it 'knows the percentage completed after it has been incremented' do
-    progress = Progress.new(:total => 50)
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:total => 50, :projector => projector)
 
     progress.start
     progress.increment
@@ -78,7 +88,8 @@ describe Progress do
   end
 
   it 'knows to always round down the percentage completed' do
-    progress = Progress.new(:total => 200)
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:total => 200, :projector => projector)
 
     progress.start :at => 1
 
@@ -86,7 +97,8 @@ describe Progress do
   end
 
   it 'cannot increment past the total' do
-    progress = Progress.new(:total => 50)
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:total => 50, :projector => projector)
 
     progress.start :at => 50
     progress.increment
@@ -96,7 +108,8 @@ describe Progress do
   end
 
   it 'allow progress to be decremented once it is finished' do
-    progress = Progress.new(:total => 50)
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:total => 50, :projector => projector)
 
     progress.start :at => 50
     progress.decrement
@@ -107,7 +120,8 @@ describe Progress do
 
   # rubocop:disable RSpec/BeEql
   it 'knows the running average even when progress has been made' do
-    progress = Progress.new(:total => 50)
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:total => 50, :projector => projector)
 
     progress.running_average = 10
     progress.start :at => 0
@@ -120,7 +134,8 @@ describe Progress do
   end
 
   it 'knows the running average is reset even after progress is started' do
-    progress = Progress.new(:total => 50)
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:total => 50, :projector => projector)
 
     progress.running_average = 10
     progress.start :at => 0
@@ -131,24 +146,18 @@ describe Progress do
 
     expect(progress.running_average).to eql 0.0
   end
-
-  it 'allows the default running average rate to be overridden' do
-    expect(Progress.new(:running_average_rate => 0.3).running_average_rate).to eql 0.3
-  end
-
-  it 'has a default running average rate' do
-    expect(Progress.new.running_average_rate).to eql 0.1
-  end
   # rubocop:enable RSpec/BeEql
 
   it 'knows the percentage completed is 100% if the total is zero' do
-    progress = Progress.new(:total => 0)
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:total => 0, :projector => projector)
 
     expect(progress.percentage_completed).to be 100
   end
 
   it 'raises an error when passed a number larger than the total' do
-    progress = Progress.new(:total => 100)
+    projector  = Calculators::SmoothedAverage.new
+    progress   = Progress.new(:total => 100, :projector => projector)
 
     expect { progress.progress = 101 }.
       to \

--- a/spec/lib/ruby-progressbar/progress_spec.rb
+++ b/spec/lib/ruby-progressbar/progress_spec.rb
@@ -123,7 +123,7 @@ describe Progress do
     projector  = Calculators::SmoothedAverage.new
     progress   = Progress.new(:total => 50, :projector => projector)
 
-    progress.running_average = 10
+    projector.__send__(:projection=, 10)
     progress.start :at => 0
 
     expect(progress.running_average).to be_zero
@@ -137,7 +137,7 @@ describe Progress do
     projector  = Calculators::SmoothedAverage.new
     progress   = Progress.new(:total => 50, :projector => projector)
 
-    progress.running_average = 10
+    projector.__send__(:projection=, 10)
     progress.start :at => 0
 
     expect(progress.running_average).to be_zero

--- a/spec/lib/ruby-progressbar/progress_spec.rb
+++ b/spec/lib/ruby-progressbar/progress_spec.rb
@@ -129,6 +129,7 @@ describe Progress do
 
     expect(progress.running_average).to be_zero
 
+    projector.progress += 40
     progress.progress += 40
 
     expect(progress.running_average).to eql 36.0

--- a/spec/lib/ruby-progressbar/projector/smoothed_average_spec.rb
+++ b/spec/lib/ruby-progressbar/projector/smoothed_average_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-require 'ruby-progressbar/calculators/smoothed_average'
+require 'ruby-progressbar/projectors/smoothed_average'
 
 class    ProgressBar
-module   Calculators
+module   Projectors
 describe SmoothedAverage do
   describe '.calculate' do
     it 'can properly calculate a projection' do

--- a/spec/lib/ruby-progressbar/projector_spec.rb
+++ b/spec/lib/ruby-progressbar/projector_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'ruby-progressbar/projector'
+
+class    ProgressBar
+describe Projector do
+  describe '.from_type' do
+    it 'has a default projector' do
+      projector = Projector.from_type(nil)
+
+      expect(projector).to be ProgressBar::Calculators::SmoothedAverage
+    end
+
+    it 'can return a specific projector' do
+      projector = Projector.from_type('smoothed')
+
+      expect(projector).to be ProgressBar::Calculators::SmoothedAverage
+    end
+  end
+end
+end

--- a/spec/lib/ruby-progressbar/projector_spec.rb
+++ b/spec/lib/ruby-progressbar/projector_spec.rb
@@ -7,13 +7,13 @@ describe Projector do
     it 'has a default projector' do
       projector = Projector.from_type(nil)
 
-      expect(projector).to be ProgressBar::Calculators::SmoothedAverage
+      expect(projector).to be ProgressBar::Projectors::SmoothedAverage
     end
 
     it 'can return a specific projector' do
       projector = Projector.from_type('smoothed')
 
-      expect(projector).to be ProgressBar::Calculators::SmoothedAverage
+      expect(projector).to be ProgressBar::Projectors::SmoothedAverage
     end
   end
 end


### PR DESCRIPTION
Why This Change Is Necessary
========================================================================

The current projector we've had in the code for over a decade now has
served us well, but there has been a desire to have some different types
of projectors (eg windowed by item count or by time).  This was
previously difficult to do but with this change we should be able to
allow the user to swap different ones out fairly easily.

What These Changes Do To Address the Issue
========================================================================

Add a new `Projector` class that manages all other projectors.

Side Effects Caused By This Change
========================================================================

None expected.