### PR TITLE
Add `%d` -> `:estimated_with_days`.

### DIFF
--- a/lib/ruby-progressbar/components/time.rb
+++ b/lib/ruby-progressbar/components/time.rb
@@ -5,6 +5,7 @@ class   ProgressBar
 module  Components
 class   Time
   TIME_FORMAT            = '%02d:%02d:%02d'.freeze
+  DAY_FORMAT            = '%dd %02d:%02d:%02d'.freeze
   OOB_TIME_FORMATS       = [:unknown, :friendly, nil].freeze
   OOB_LIMIT_IN_HOURS     = 99
   OOB_UNKNOWN_TIME_TEXT  = '??:??:??'.freeze
@@ -42,6 +43,16 @@ class   Time
 
   def estimated_with_friendly_oob
     estimated_with_elapsed_fallback(:friendly)
+  end
+
+  def estimated_with_days
+    memo_estimated_seconds_remaining = estimated_seconds_remaining
+
+    return OOB_UNKNOWN_TIME_TEXT unless memo_estimated_seconds_remaining
+
+    hours, minutes, seconds = timer.divide_seconds(memo_estimated_seconds_remaining)
+    days, hours = hours / 24, hours % 24
+    DAY_FORMAT % [days, hours, minutes, seconds]
   end
 
   def estimated_wall_clock

--- a/lib/ruby-progressbar/format/molecule.rb
+++ b/lib/ruby-progressbar/format/molecule.rb
@@ -16,6 +16,7 @@ class   Molecule
     :E => [:time_component,       :estimated_with_friendly_oob],
     :f => [:time_component,       :estimated_with_no_oob],
     :l => [:time_component,       :estimated_wall_clock],
+    :d => [:time_component,       :estimated_with_days],
     :B => [:bar_component,        :complete_bar],
     :b => [:bar_component,        :bar],
     :W => [:bar_component,        :complete_bar_with_percentage],


### PR DESCRIPTION
<!--lint ignore first-heading-level-->

See issue described in #191;
I am running some exceedingly long processes and need to see how many days they require.

* [] Bug Fix
* [x] New Feature

I added a `%d` label inside the formatter to render the number of days, alongside normal `HH:MM:SS`.
Durations less than 24 hours render as `0d HH:MM:SS`.

Side Effects Caused By This Change
--------------------------------------------------------------------------------

* [] This Causes a Breaking Change
* [x] This Does Not Cause Any Known Side Effects

Screenshots
--------------------------------------------------------------------------------

```
#116: |=====                                                           |  8.22% ( 1366 / 16601 ) 9d 03:26:22
```

Checklist
--------------------------------------------------------------------------------

* [] I have run `rubocop` against the codebase
* [] I have added tests to cover my changes
* [x] All ~new and~ existing tests passed