### PR TITLE
Make the progressbar and ruby-progressbar gems only differ in their names, but have the exact same content.

### DIFF
--- a/lib/progressbar.rb
+++ b/lib/progressbar.rb
@@ -1,12 +1,1 @@
-# frozen_string_literal: true
-
-require 'ruby-progressbar/base'
-require 'ruby-progressbar/refinements' if Module.
-                                         private_instance_methods.
-                                         include?(:using)
-
-class ProgressBar
-  def self.create(*args)
-    ProgressBar::Base.new(*args)
-  end
-end
+ruby-progressbar.rb

--- a/progressbar.gemspec
+++ b/progressbar.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.signing_key   = File.expand_path('~/.gem/certs/jfelchner-private_key.pem') if $0 =~ /gem\z/
 
   spec.executables   = []
-  spec.files         = Dir['{app,config,db,lib/ruby-progressbar}/**/*'] + %w{lib/progressbar.rb Rakefile README.md LICENSE.txt}
+  spec.files         = Dir['{app,config,db,lib/ruby-progressbar}/**/*'] + %w{lib/progressbar.rb lib/ruby-progressbar.rb Rakefile README.md LICENSE.txt}
 
   spec.metadata      = {
     'bug_tracker_uri'   => 'https://github.com/jfelchner/ruby-progressbar/issues',

--- a/ruby-progressbar.gemspec
+++ b/ruby-progressbar.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.signing_key   = File.expand_path('~/.gem/certs/jfelchner-private_key.pem') if $0 =~ /gem\z/
 
   spec.executables   = []
-  spec.files         = Dir['{app,config,db,lib/ruby-progressbar}/**/*'] + %w{lib/ruby-progressbar.rb Rakefile README.md LICENSE.txt}
+  spec.files         = Dir['{app,config,db,lib/ruby-progressbar}/**/*'] + %w{lib/progressbar.rb lib/ruby-progressbar.rb Rakefile README.md LICENSE.txt}
 
   spec.metadata      = {
     'bug_tracker_uri'   => 'https://github.com/jfelchner/ruby-progressbar/issues',


### PR DESCRIPTION
---

name:  Pull Request
about: Make the progressbar and ruby-progressbar gems only differ in their names, but have the exact same content.

---

Let both the ruby-progressbar and progressbar gems allow requiring progressbar or ruby-progessbar indifferently.

Why: Having the 2 gems with quite the same content but not exactly is very
confusing, for instance, on Debian because the ruby-progressbar deb
package contains the progressbar gem, not the ruby-progressbar
gem.

IMHO, having both gems with the exact same content would be more
user-friendly, allowing 'require "progressbar"' and 'require
"ruby-progressbar"' indifferently, independently of what gem is actually installed
(be it with gem install or a distribution package).